### PR TITLE
Profiling

### DIFF
--- a/benchmark_tests/benchmark.py
+++ b/benchmark_tests/benchmark.py
@@ -1,4 +1,5 @@
 import mxnet as mx
+from mxnet import profiler
 import numpy as np
 import os, sys,time
 import logging
@@ -11,6 +12,8 @@ def feed_args(net, arg_arrays):
             arr[:] = 0.0
 
 def test():
+    profiler.set_config(profile_all=True, aggregate_stats=True,
+            filename='profile_output.json')
     mx.base.swap_start_iteration()
     print(sys.argv)
     parser = argparse.ArgumentParser("Benchmark Tests")
@@ -73,6 +76,8 @@ def test():
     #t0 = time.time()
     for i in range(num_loops):
         print('=> loop %d' % i);
+        if i == 3:
+            profiler.set_state('run')
         mx.base.swap_start_iteration()
         st_l = time.time()
         outputs = executor.forward()
@@ -87,6 +92,8 @@ def test():
         mx.base.swap_stop_iteration()
         ed_l = time.time()
         mx.base.swap_statistics()
+        if i == 3:
+            profiler.set_state('stop')
 
         print('=> loop duration %f\n' % float(ed_l - st_l))
         if i > 1:

--- a/benchmark_tests/json_parse.py
+++ b/benchmark_tests/json_parse.py
@@ -1,0 +1,32 @@
+import json
+
+with open("profile_output.json", "r") as infile:
+    js_p = json.load(infile)
+
+with open("resnet.json", "r") as infile:
+    js_d = json.load(infile);
+
+i = 0
+_events = js_p["traceEvents"]
+events = []
+for event in _events:
+    if event['ph'] != 'M' and event['pid'] == 24:
+        events.append(event)
+
+for j, node in enumerate(js_d["nodes"]):
+    time = 0
+    #print(i,j)
+    if node["op"] != "null":
+        if events[i]["name"] != node["op"]:
+            print("At ts =", events[i]["ts"], "i =", i, "op and operator does not match")
+            print("Profiler =", events[i]["name"])
+            print("Expected =", node["op"])
+            break;
+        time = events[i+1]["ts"] - events[i]["ts"]
+        while j != len(js_d["nodes"])-1 and events[i+2]["ts"] < events[i+1]["ts"]:
+            i+=2
+        i+=2
+    node["time"] = time
+
+with open("resnet_time.json", "w") as outfile:
+    json.dump(js_d, outfile, sort_keys=True, indent=4)


### PR DESCRIPTION
1. Add Profiling to benchmark.py to let MXNet's original profiler record runtime information
2. Add a script to extract elapsed time of each node from profiler's output, and insert it into corresponding node in the dataflow graph

Notes:
1. The json output of profiler give two pairs of info on almost every nodes. However, the elapsed time calculated from this two pairs of node are usually very very close. So in my script I just only use the first one pair.
2. Tested with several layer size of resnet, with/without using swap, but only on resnet
3. It maybe a good idea to make json_parse part of benchmark.py, so that we can have less output file. Also the output file name of profiler cannot be changed during runtime, which means I do not have a good way to get info on several iterations and get average of it without making the output file really large & hard to process.