### PR TITLE
Gpu swap infinity

### DIFF
--- a/src/storage/gpu_swap.h
+++ b/src/storage/gpu_swap.h
@@ -57,6 +57,7 @@ private:
   pthread_rwlock_t locks_[NUMBER_OF_GPU];
   bool swap_locked_;
   bool swap_async_;
+  bool infinite_memory_;
   cudaStream_t streams_[NUMBER_OF_GPU];
 }; // Class Swap
 

--- a/src/storage/gpu_swap.h
+++ b/src/storage/gpu_swap.h
@@ -58,7 +58,8 @@ private:
   bool swap_locked_;
   bool swap_async_;
   bool infinite_memory_;
-  cudaStream_t streams_[NUMBER_OF_GPU];
+  cudaStream_t streams_out_[NUMBER_OF_GPU];
+  cudaStream_t streams_in_[NUMBER_OF_GPU];
 }; // Class Swap
 
 } // namespace mxnet

--- a/src/storage/gpu_swap_history.cc
+++ b/src/storage/gpu_swap_history.cc
@@ -23,6 +23,10 @@ MemoryHistory::MemoryHistory() {
   iteration_idx_ = 0;
   swap_algorithm_ = dmlc::GetEnv("MXNET_SWAP_ALGORITHM", std::string("LRU"));
   adaptive_history_ = dmlc::GetEnv("MXNET_ADAPTIVE_HISTORY", false);
+  bool infinite_memory = dmlc::GetEnv("MXNET_INFINITE_MEMORY", false);
+  if (infinite_memory) {
+      swap_algorithm_ = "SizeHistory";
+  }
   dev_history_.resize(NUMBER_OF_GPU);
   std::cout << "Swap Algorithm: " << swap_algorithm_ << std::endl;
   if (swap_algorithm_ == "LRU") {

--- a/src/storage/gpu_swap_memmgr.h
+++ b/src/storage/gpu_swap_memmgr.h
@@ -86,6 +86,26 @@ class BuddyMemoryManager : public MemoryManager {
     std::array<std::mutex, 16> mutex_;
 }; // Class BuddyMemoryManager
 
+class FakeMemoryManager : public MemoryManager {
+  public:
+    cudaError_t MemGetInfo(int device_id, size_t* total, size_t* free);
+    bool TryAllocate(int device_id, size_t size);
+
+    friend std::shared_ptr<MemoryManager> GetMemoryManagerRef();
+
+  protected:
+    cudaError_t MallocInternal(void*& devptr, size_t size, int device_id);
+    cudaError_t FreeInternal(void* devptr, int device_id);
+    void StatisticsInternal();
+
+  private:
+    FakeMemoryManager();
+    ~FakeMemoryManager();
+    
+    std::vector<void*> ptrs_;
+}; // Class BuddyMemoryManager
+
+
 //class SlabMemoryManager : public MemoryManager {
   //public:
     //cudaError_t MemGetInfo(int device_id, size_t* total, size_t* free);

--- a/src/storage/gpu_swap_prefetch.cc
+++ b/src/storage/gpu_swap_prefetch.cc
@@ -20,7 +20,7 @@ Prefetch::Prefetch() {
                                       std::string("NaiveHistory"));
   steps_ahead_ = dmlc::GetEnv("MXNET_PREFETCH_STEP_AHEAD", 100);
   bool infinite_memory = dmlc::GetEnv("MXNET_INFINITE_MEMORY", false);
-  if (!infinite_memory) {
+  if (infinite_memory) {
       prefetch_algorithm_ = "NoPrefetch";
   }
   history_ = MemoryHistory::_GetSharedRef();

--- a/src/storage/gpu_swap_prefetch.cc
+++ b/src/storage/gpu_swap_prefetch.cc
@@ -19,6 +19,10 @@ Prefetch::Prefetch() {
   prefetch_algorithm_ = dmlc::GetEnv("MXNET_PREFETCH_ALGORITHM",
                                       std::string("NaiveHistory"));
   steps_ahead_ = dmlc::GetEnv("MXNET_PREFETCH_STEP_AHEAD", 100);
+  bool infinite_memory = dmlc::GetEnv("MXNET_INFINITE_MEMORY", false);
+  if (!infinite_memory) {
+      prefetch_algorithm_ = "NoPrefetch";
+  }
   history_ = MemoryHistory::_GetSharedRef();
   lookahead_pos_.resize(NUMBER_OF_GPU);
   prefetcher_.resize(NUMBER_OF_GPU);


### PR DESCRIPTION
There are two implementations. The first one is implementing a fake memory manager which always returns the same address for a memory request. However, this cause CUDA behaves weirdly for some unknown reasons. The second one is disabling the communication overhead of swapping such that the swapping's performance will be close to with infinite memory.