### PR TITLE
(WIP) SwapAdvisor scheduler enforcer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Test results
+benchmark_tests/
+
 # Compiled Object files
 *.slo
 *.lo

--- a/src/engine/engine.cc
+++ b/src/engine/engine.cc
@@ -43,6 +43,8 @@ inline Engine* CreateEngine() {
     ret = CreateThreadedEnginePooled();
   } else if (stype == "ThreadedEnginePerDevice") {
     ret = CreateThreadedEnginePerDevice();
+  } else if (stype == "SwapAdvisorEngine") {
+    ret = CreateSwapAdvisorEngine();
   }
   #else
   ret = CreateNaiveEngine();

--- a/src/engine/engine_impl.h
+++ b/src/engine/engine_impl.h
@@ -95,6 +95,8 @@ Engine *CreateNaiveEngine();
 Engine *CreateThreadedEnginePooled();
 /*! \return ThreadedEnginePerDevie instance */
 Engine *CreateThreadedEnginePerDevice();
+/*! \return SwapAdvisorEngine instance */
+Engine *CreateSwapAdvisorEngine();
 #endif
 }  // namespace engine
 }  // namespace mxnet

--- a/src/engine/swap_advisor_engine.cc
+++ b/src/engine/swap_advisor_engine.cc
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ *  Copyright (c) 2015 by Contributors
+ * \file swap_advisor_engine.cc
+ * \brief Implementation of SwapAdvisorEngine
+ *  It is build upon implementation of Naive Engine.
+ */
+#include <vector>
+#include <atomic>
+#include <thread>
+#include "./engine_impl.h"
+#include "../profiler/profiler.h"
+#include "./openmp.h"
+
+namespace mxnet {
+namespace engine {
+
+// implement naive engine
+class SwapAdvisorEngine final : public Engine {
+ public:
+  struct NaiveOpr : public Opr {
+    AsyncFn fn;
+    std::vector<VarHandle> const_vars;
+    std::vector<VarHandle> mutable_vars;
+    FnProperty prop;
+    const char* opr_name;
+    /*! \brief indicate whether to profile this operator */
+    bool profiling{false};
+    /*! \brief operator execution statistics */
+    std::unique_ptr<profiler::ProfileOperator> opr_profile;
+  };
+
+  SwapAdvisorEngine() {
+    ReadScheduling();
+    next_opr_ = 0;
+  }
+  // virtual destructor
+  virtual ~SwapAdvisorEngine() {
+#if MXNET_USE_CUDA
+    LOG(INFO) << "Engine shutdown";
+    for (size_t i = 0; i < streams_.size(); ++i) {
+      if (streams_[i] != nullptr) {
+        // Catch exception for CUDA driver shutdown
+        MSHADOW_CATCH_ERROR(mshadow::DeleteStream(streams_[i]));
+        streams_[i] = nullptr;
+      }
+    }
+#endif
+  }
+
+  void Stop() override {
+  }
+
+  void Start() override {
+  }
+
+  // new variables
+  VarHandle NewVariable() override {
+    size_t v = ++counter_;
+    return reinterpret_cast<VarHandle>(v);
+  }
+
+  OprHandle NewOperator(AsyncFn fn,
+                        std::vector<VarHandle> const& const_vars,
+                        std::vector<VarHandle> const& mutable_vars,
+                        FnProperty prop = FnProperty::kNormal,
+                        const char* opr_name = nullptr,
+                        bool wait = false) override {
+    NaiveOpr *opr = new NaiveOpr();
+    opr->fn = fn;
+    opr->const_vars = const_vars;
+    opr->mutable_vars = mutable_vars;
+    opr->prop = prop;
+    opr->opr_name = opr_name;
+    return opr;
+  }
+
+  void DeleteOperator(OprHandle op) override {
+    NaiveOpr *opr = op->Cast<NaiveOpr>();
+    delete opr;
+  }
+
+  // priority variable stores node id of the node for this engine.
+  /* (TODO: Sotskin) Test this function. Current idea
+   * Use a map to store mapping: node_id -> {op, exec_ctx, profiling}
+   * If current op is the next to be run according to scheduling, run it,
+   * Otherwise, store the information in map.
+   *
+   * After current op is ran, call a function to check if next op is in the
+   * map, and run it if it is.
+   */
+  void Push(OprHandle op, Context exec_ctx, int priority = 0, bool profiling = false) override {
+    NaiveOpr *opr = op->Cast<NaiveOpr>();
+    size_t node_id = priority;
+    opr_info_map[node_id] = (OprInfo){opr, exec_ct, profiling};
+    DoPush(exec_order_[next_opr_]);
+  }
+
+  void PushAsync(AsyncFn exec_fun,
+                 Context exec_ctx,
+                 std::vector<VarHandle> const& const_vars,
+                 std::vector<VarHandle> const& mutable_vars,
+                 FnProperty prop = FnProperty::kNormal,
+                 int priority = 0,
+                 const char* opr_name = nullptr,
+                 bool wait = false) override {
+    CallbackOnComplete callback = CreateCallback(
+        SwapAdvisorEngine::OnComplete, nullptr);
+    this->req_completed_ = false;
+    profiler::Profiler *profiler = profiler::Profiler::Get();
+    NaiveOpr *opr = nullptr;
+    const bool profiling = opr_name && profiler->IsProfiling(profiler::Profiler::kImperative);
+    if (profiling) {
+      opr = NewOperator(exec_fun, const_vars, mutable_vars,
+                        prop, opr_name)->Cast<NaiveOpr>();
+      opr->profiling = profiling;
+      std::unique_ptr<profiler::ProfileOperator::Attributes> attrs;
+      if (profiler->AggregateEnabled()) {
+        attrs.reset(new profiler::ProfileOperator::Attributes());
+      }
+      opr->opr_profile.reset(new profiler::ProfileOperator(opr->opr_name, attrs.release()));
+      opr->opr_profile->start(exec_ctx.dev_type, exec_ctx.dev_id);
+    }
+    if (exec_ctx.dev_mask() == gpu::kDevMask) {
+#if MXNET_USE_CUDA
+      size_t dev_id = static_cast<size_t>(exec_ctx.dev_id);
+      MSHADOW_CATCH_ERROR(mshadow::SetDevice<gpu>(exec_ctx.dev_id));
+      if (streams_.size() <= dev_id) {
+        streams_.resize(dev_id + 1, nullptr);
+      }
+      if (streams_[dev_id] == nullptr) {
+        streams_[dev_id] = mshadow::NewStream<gpu>(true, MXNET_USE_CUDNN != 0, dev_id);
+      }
+      exec_fun(RunContext{exec_ctx, streams_[dev_id]}, callback);
+#else
+      LOG(FATAL) << "GPU is not enabled";
+#endif
+    } else {
+      exec_fun(RunContext{exec_ctx, &cpu_stream_}, callback);
+    }
+    CHECK(this->req_completed_)
+        << "SwapAdvisorEngine only support synchronize Push so far";
+    if (profiling) {
+      opr->opr_profile->stop();
+    }
+  }
+
+  void DeleteVariable(SyncFn delete_fn, Context exec_ctx, VarHandle var) override {
+    this->PushSync(delete_fn, exec_ctx, {}, {var},
+                   FnProperty::kNormal, 0, "DeleteVariable");
+  }
+
+  void WaitForVar(VarHandle var) override {
+  }
+
+  void WaitForAll() override {
+  }
+
+  void NotifyShutdown() override {
+    shutdown_phase_.store(true);
+  }
+
+ private:
+  struct OprInfo {
+    NaiveOpr *opr; 
+    Context exec_ctx;
+    bool profiling;
+  }
+  // Read dataflow scheduling.
+  void ReadSchedule() {
+     
+  }
+  // Check if requested opr is ready and run it.
+  void DoPush(size_t node_id) {
+    if(opr_info_map_.find(node_id) == opr_info_map_.end()) return;
+    next_opr_ ++;
+    NaiveOpr *opr = opr_info_map_[node_id].opr; 
+    Contect exec_ctx = opr_info_map_[node_id].exec_ctx;
+    bool profiling = opr_info_map_[node_id].profiling;
+    profiler::Profiler *profiler = profiler::Profiler::Get();
+    opr->profiling = profiling && profiler->IsProfiling(profiler::Profiler::kSymbolic);
+    this->PushAsync([&](RunContext ctx, CallbackOnComplete on_complete) {
+        if (opr->profiling) {
+          std::unique_ptr<profiler::ProfileOperator::Attributes> attrs;
+          if (profiler->AggregateEnabled()) {
+            attrs.reset(new profiler::ProfileOperator::Attributes());
+          }
+          opr->opr_profile.reset(new profiler::ProfileOperator(opr->opr_name, attrs.release()));
+          opr->opr_profile->start(exec_ctx.dev_type, exec_ctx.dev_id);
+        }
+        opr->fn(ctx, on_complete);
+        if (opr->profiling) {
+          opr->opr_profile->stop();
+        }
+      },
+      exec_ctx,
+      opr->const_vars,
+      opr->mutable_vars,
+      opr->prop,
+      priority,
+      opr->opr_name);  
+  }
+  // callback to oncomplete
+  static void OnComplete(Engine *engine, void *param) {
+    static_cast<SwapAdvisorEngine*>(engine)->req_completed_ = true;
+  }
+  // whether action is completed
+  bool req_completed_;
+  // counter
+  std::atomic<size_t> counter_{0};
+  /*! \brief whether it is during shutdown phase*/
+  std::atomic<bool> shutdown_phase_{false};
+  // CPU stream
+  mshadow::Stream<cpu> cpu_stream_;
+  // GPU streams
+  std::vector<mshadow::Stream<gpu>*> streams_;
+  /*! \brief order of execution by nodeid given by scheduler. */
+  std::vector<size_t> exec_order_;
+  /*! \brief node id of next opr to be run */
+  size_t next_opr_;
+  /*! \brief map that stores operator info for nodes that haven't been run yet */
+  std::map<size_t, OprInfo> opr_info_map_;
+};  // class SwapAdvisorEngine
+
+Engine *CreateSwapAdvisorEngine() {
+  return new SwapAdvisorEngine();
+}
+}  // namespace engine
+}  // namespace mxnet

--- a/src/engine/swap_advisor_engine.cc
+++ b/src/engine/swap_advisor_engine.cc
@@ -49,7 +49,7 @@ class SwapAdvisorEngine final : public Engine {
   };
 
   SwapAdvisorEngine() {
-    ReadScheduling();
+    ReadSchedule();
     next_opr_ = 0;
   }
   // virtual destructor
@@ -110,7 +110,7 @@ class SwapAdvisorEngine final : public Engine {
   void Push(OprHandle op, Context exec_ctx, int priority = 0, bool profiling = false) override {
     NaiveOpr *opr = op->Cast<NaiveOpr>();
     size_t node_id = priority;
-    opr_info_map[node_id] = (OprInfo){opr, exec_ct, profiling};
+    opr_info_map_[node_id] = (OprInfo){opr, exec_ctx, profiling};
     DoPush(exec_order_[next_opr_]);
   }
 
@@ -183,7 +183,7 @@ class SwapAdvisorEngine final : public Engine {
     NaiveOpr *opr; 
     Context exec_ctx;
     bool profiling;
-  }
+  };
   // Read dataflow scheduling.
   void ReadSchedule() {
      
@@ -193,7 +193,7 @@ class SwapAdvisorEngine final : public Engine {
     if(opr_info_map_.find(node_id) == opr_info_map_.end()) return;
     next_opr_ ++;
     NaiveOpr *opr = opr_info_map_[node_id].opr; 
-    Contect exec_ctx = opr_info_map_[node_id].exec_ctx;
+    Context exec_ctx = opr_info_map_[node_id].exec_ctx;
     bool profiling = opr_info_map_[node_id].profiling;
     profiler::Profiler *profiler = profiler::Profiler::Get();
     opr->profiling = profiling && profiler->IsProfiling(profiler::Profiler::kSymbolic);
@@ -215,7 +215,7 @@ class SwapAdvisorEngine final : public Engine {
       opr->const_vars,
       opr->mutable_vars,
       opr->prop,
-      priority,
+      0,
       opr->opr_name);  
   }
   // callback to oncomplete

--- a/src/engine/swap_advisor_engine.cc
+++ b/src/engine/swap_advisor_engine.cc
@@ -68,7 +68,11 @@ class SwapAdvisorEngine final : public ThreadedEngine {
    * map, and run it if it is.
    */
   void PushToExecute(OprBlock *opr_block, bool pusher_thread) override {
-    if((size_t)opr_block->priority == exec_order_[next_opr_]) {
+    // (TODO: Sotskin) Here we check whether OprBlock is a swapin/swapout opr
+    if (false) {
+      DoExecute(opr_block);
+    }
+    else if((size_t)opr_block->priority == exec_order_[next_opr_]) {
       DoExecute(opr_block); 
       next_opr_++;
       if(opr_block_map_.find(exec_order_[next_opr_]) != 

--- a/src/executor/graph_executor.cc
+++ b/src/executor/graph_executor.cc
@@ -41,6 +41,7 @@ using namespace mxnet::common;
 
 GraphExecutor::GraphExecutor() {
   log_verbose_ = dmlc::GetEnv("MXNET_EXEC_VERBOSE_LOGGING", false);
+  pass_node_id_ = dmlc::GetEnv("MXNET_SWAPADVISOR_SCHEDULING", false);
   need_grad_ = false;
 }
 
@@ -1351,7 +1352,9 @@ void GraphExecutor::RunOps(bool is_train, size_t topo_start, size_t topo_end) {
       opnode.exec->Run(opnode.exec->op_ctx.run_ctx, false);
     } else if (opnode.cached_opr != nullptr) {
       bool profiling = profiler::Profiler::Get()->GetState() == profiler::Profiler::kRunning;
-      Engine::Get()->Push(opnode.cached_opr, opnode.ctx, 0, profiling);
+      // Pass node id if enabled for scheduling
+      bool node_id = pass_node_id_? nid : 0;
+      Engine::Get()->Push(opnode.cached_opr, opnode.ctx, node_id, profiling);
     } else {
       LOG(FATAL) << "Not accessed";
     }

--- a/src/executor/graph_executor.h
+++ b/src/executor/graph_executor.h
@@ -256,6 +256,8 @@ class GraphExecutor : public Executor {
   std::unordered_set<std::string> cached_seg_opr_names_;
   // verbose logging
   bool log_verbose_ = false;
+  // enable passing node id for SwapAdvisor scheduling
+  bool pass_node_id_ = false;
 };
 
 }  // namespace exec


### PR DESCRIPTION
1. Pass node_id from GraphExecutor to Engine, by using an unused argument of `Push` called `priority` when setting the model to use SwapAdvisor.
2. (WIP) New engine created to apply the output of SwapAdvisor's scheduling to MXNet.  It builds upon MXNet's NaiveEngine
