### PR TITLE
Swap advisor on demand

### DIFF
--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -229,6 +229,10 @@ MXNET_DLL int MXRandomSeedContext(int seed, int dev_type, int dev_id);
  */
 MXNET_DLL int MXNotifyShutdown();
 
+MXNET_DLL int MXSwapStartIteration();
+MXNET_DLL int MXSwapStopIteration();
+MXNET_DLL int MXSwapStatistics();
+
 /*!
  * \brief Set up configuration of profiler for the process passed as profile_process in keys
  * \param num_params Number of parameters

--- a/python/mxnet/base.py
+++ b/python/mxnet/base.py
@@ -504,6 +504,14 @@ def _notify_shutdown():
 
 atexit.register(_notify_shutdown)
 
+def swap_start_iteration():
+    check_call(_LIB.MXSwapStartIteration())
+
+def swap_stop_iteration():
+    check_call(_LIB.MXSwapStopIteration())
+
+def swap_statistics():
+    check_call(_LIB.MXSwapStatistics())
 
 def add_fileline_to_docstring(module, incursive=True):
     """Append the definition position to each function contained in module.

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -46,6 +46,7 @@
 #include "./c_api_common.h"
 #include "../operator/custom/custom-inl.h"
 #include "../operator/tensor/matrix_op-inl.h"
+#include "../storage/gpu_swap_history.h"
 
 using namespace mxnet;
 
@@ -101,6 +102,24 @@ int MXRandomSeedContext(int seed, int dev_type, int dev_id) {
 int MXNotifyShutdown() {
   API_BEGIN();
   Engine::Get()->NotifyShutdown();
+  API_END();
+}
+
+int MXSwapStartIteration() {
+  API_BEGIN();
+  MemoryHistory::Get()->StartIteration();
+  API_END();
+}
+
+int MXSwapStopIteration() {
+  API_BEGIN();
+  MemoryHistory::Get()->StopIteration();
+  API_END();
+}
+
+int MXSwapStatistics() {
+  API_BEGIN();
+  MemoryHistory::Get()->Statistics();
   API_END();
 }
 

--- a/src/executor/graph_executor.cc
+++ b/src/executor/graph_executor.cc
@@ -34,6 +34,8 @@
 #include "../profiler/profiler.h"
 #include "../common/utils.h"
 #include "../common/exec_utils.h"
+#include "../storage/gpu_swap.h"
+#include "../storage/gpu_swap_prefetch.h"
 
 namespace mxnet {
 namespace exec {
@@ -1263,6 +1265,7 @@ void GraphExecutor::InitCachedOps() {
       std::cout << "[RUNNING]: ID = " <<  nid << ", " << "NAME = " << name
                 << std::endl;
 #endif
+      Swap::Get()->PrePostAccess(true);
       exec->Run(ctx, is_gpu);
       // call on complete only if it is async op
       if (!is_async) {
@@ -1270,11 +1273,13 @@ void GraphExecutor::InitCachedOps() {
         #if MXNET_USE_CUDA
           // Wait GPU kernel to finish.
           ctx.get_stream<gpu>()->Wait();
+          Prefetch::Get()->SignalStopComputing();
         #else
           LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
         #endif
         }
         on_complete();
+        Swap::Get()->PrePostAccess(false);
       }
 #if SWAP_ADVISOR_FLOW_TRACE
       std::cout << "[RUNNING]: DONE, " << nid << std::endl;
@@ -1567,6 +1572,7 @@ GraphExecutor::CachedSegOpr GraphExecutor::CreateCachedSegOpr(size_t topo_start,
   auto exec_fun = [exec_list, is_gpu] (
       RunContext ctx, Engine::CallbackOnComplete on_complete) {
     // Run all opr in the sub-graph
+    Swap::Get()->PrePostAccess(true);
     for (auto &exec : exec_list) {
       exec->Run(ctx, is_gpu);
     }
@@ -1574,11 +1580,13 @@ GraphExecutor::CachedSegOpr GraphExecutor::CreateCachedSegOpr(size_t topo_start,
 #if MXNET_USE_CUDA
       // Wait GPU kernel to finish.
       ctx.get_stream<gpu>()->Wait();
+      Prefetch::Get()->SignalStopComputing();
 #else
       LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
 #endif
     }
     on_complete();
+    Swap::Get()->PrePostAccess(false);
   };
   opr_names.pop_back();
   opr_names += "]";

--- a/src/storage/gpu_swap.cc
+++ b/src/storage/gpu_swap.cc
@@ -1,0 +1,476 @@
+#include <dmlc/logging.h>
+#include <dmlc/parameter.h>
+#include "../common/cuda_utils.h"
+#include "./gpu_swap.h"
+
+//#define FEGIN_DEBUG
+
+namespace mxnet{
+
+SwapInfoGroups::SwapInfoGroups() { }
+
+SwapInfoGroups::~SwapInfoGroups() { }
+
+std::shared_ptr<SwapInfoGroups> SwapInfoGroups::_GetSharedRef() {
+  static std::shared_ptr<SwapInfoGroups> inst(new SwapInfoGroups());
+  return inst;
+}
+
+SwapInfoGroups* SwapInfoGroups::Get() {
+  static SwapInfoGroups *sig = _GetSharedRef().get();
+  return sig;
+}
+
+void SwapInfoGroups::NewInfo(void* addr, SwapInfo* info) {
+  // We don't check the duplication here. It's caller's resposibility to make
+  // sure this API is called when a new SwapInfo is created.
+  auto it = in_memory_.find(addr);
+  if (it == in_memory_.end()) {
+    std::shared_ptr<SIGroup> group(new SIGroup());
+    in_memory_[addr] = group;
+    all_[info] = group;
+  } else {
+    std::cout << "Existed " << std::endl;
+    it->second->push_back(info);
+    all_[info] = it->second;
+  }
+}
+
+std::shared_ptr<SIGroup> SwapInfoGroups::SwapOut(void* addr) {
+  auto ptr = in_memory_.at(addr);
+  in_memory_.erase(addr);
+  for (auto& info : *ptr) {
+    info->swapped_in = false;
+    info->dptr = nullptr;
+  }
+  return ptr;
+}
+
+std::shared_ptr<SIGroup> SwapInfoGroups::SwapIn(void* addr, SwapInfo* info) {
+  auto ptr = all_.at(info);
+  for (auto& info : *ptr) {
+    info->swapped_in = true;
+    info->dptr = addr;
+  }
+  in_memory_[addr] = ptr;
+  return ptr;
+}
+
+ThreadAccessInfo::ThreadAccessInfo() {
+  running_threshold_ = dmlc::GetEnv("MXNET_SWAP_ACCESS_THRESHOLD",
+                                    kAccessThreshold);
+}
+
+ThreadAccessInfo::~ThreadAccessInfo() {}
+
+std::shared_ptr<ThreadAccessInfo> ThreadAccessInfo::_GetSharedRef() {
+  static std::shared_ptr<ThreadAccessInfo> inst(new ThreadAccessInfo());
+  return inst;
+}
+
+ThreadAccessInfo* ThreadAccessInfo::Get() {
+  static ThreadAccessInfo *tai = _GetSharedRef().get();
+  return tai;
+}
+
+std::set<handle_id_t>& ThreadAccessInfo::CheckAndCreate(handle_id_t hid,
+                                                        bool access,
+                                                        bool& running) {
+  std::thread::id tid = std::this_thread::get_id();
+  auto pair = all_threads_.emplace(tid, std::set<handle_id_t>{});
+  if (pair.second) {
+    is_running[tid] = false;
+  }
+  std::set<handle_id_t>& handles = pair.first->second;
+  if (access) {
+    running = is_running[tid];
+    handles.insert(hid);
+    auto hpair = hid_to_threads_.emplace(hid,
+                                         std::unordered_set<std::thread::id>{});
+    hpair.first->second.insert(tid);
+  } else {
+    is_running[tid] = running;
+    for (auto it = handles.begin(); it != handles.end(); ) {
+      std::unordered_set<std::thread::id>& hid_to_threads = hid_to_threads_[*it];
+      hid_to_threads.erase(tid);
+#ifdef FEGIN_DEBUG
+      std::cout << "Hid=" << *it << ",size=" << hid_to_threads.size() << ",";
+      if (hid_to_threads.begin() != hid_to_threads.end()) {
+        std::cout << *(hid_to_threads.begin()) << std::endl;
+      } else {
+        std::cout << std::endl;
+      }
+#endif
+      if (hid_to_threads.size() > 0) {
+        it = handles.erase(it);
+      } else {
+        it++;
+      }
+    }
+  }
+#ifdef FEGIN_DEBUG
+  std::cout << "TID:" << tid << ",size=" << handles.size();
+  for (auto id : handles) {
+    std::cout << "," << id;
+  }
+  std::cout << std::endl;
+#endif
+  return handles;
+}
+
+handle_id_t ThreadAccessInfo::Access(handle_id_t hid) {
+  bool running = true;
+  std::set<handle_id_t>& handles = CheckAndCreate(hid, true, running);
+  if (!running && handles.size() > kAccessThreshold) {
+    handle_id_t ready_id = *(handles.begin());
+    handles.erase(handles.begin());
+    hid_to_threads_[ready_id].erase(std::this_thread::get_id());
+    if (hid_to_threads_[ready_id].size() == 0) {
+      return ready_id;
+    }
+  }
+  return kInvalidID;
+}
+
+void ThreadAccessInfo::Remove(handle_id_t hid) {
+  std::unordered_set<std::thread::id>& hid_to_threads = hid_to_threads_[hid];
+  for (auto tid : hid_to_threads) {
+    all_threads_[tid].erase(hid);
+  }
+  hid_to_threads.clear();
+}
+
+std::shared_ptr<Swap> Swap::_GetSharedRef() {
+  static std::shared_ptr<Swap> inst(new Swap());
+  return inst;
+}
+
+Swap* Swap::Get() {
+  static Swap *s = _GetSharedRef().get();
+  return s;
+}
+
+Swap::Swap() {
+  std::cout << "Initialize Swap" << std::endl;
+  swapinfo_groups_ = SwapInfoGroups::_GetSharedRef();
+  thread_info_ = ThreadAccessInfo::_GetSharedRef();
+  memory_history_ = MemoryHistory::_GetSharedRef();
+  memory_manager_ = GetMemoryManagerRef();
+  swap_lock_ = PTHREAD_RWLOCK_INITIALIZER;
+  swap_async_ = dmlc::GetEnv("MXNET_SWAP_ASYNC", true);
+  infinite_memory_ = dmlc::GetEnv("MXNET_INFINITE_MEMORY", false);
+  for (int i = 0; i < NUMBER_OF_GPU; ++i) {
+    locks_[i] = PTHREAD_RWLOCK_INITIALIZER;
+    // TODO(fegin): This and other cuda related code should be protected
+    //              by MXNET_USE_CUDA.
+    cudaStreamCreate(&streams_out_[i]);
+    cudaStreamCreate(&streams_in_[i]);
+  }
+  std::cout << "SWAP_ASYNC=" << swap_async_ << std::endl;
+  std::cout << "Initialize Swap done" << std::endl;
+}
+
+Swap::~Swap() {
+  std::cout << "Destroy Swap" << std::endl;
+}
+
+void Swap::SwapOutLocked(unsigned required_memory, int device_id, bool async) {
+  pthread_rwlock_wrlock(&swap_lock_);
+  SwapOut(required_memory, device_id, async);
+  pthread_rwlock_unlock(&swap_lock_);
+}
+
+// Caller holds swap_lock_
+void Swap::SwapOut(unsigned required_memory, int device_id, bool async) {
+  while (!memory_manager_->TryAllocate(device_id, required_memory)) {
+    SwapParams param = {0, required_memory, &divided_handles_[device_id]};
+    handle_id_t victim = memory_history_->DecideVictim(
+                            swappable_handles_[device_id], device_id, &param);
+    if (swap_info_.find(victim) == swap_info_.end()) {
+      std::cout << "Victim(" << victim
+                << ") does not exist (deleted?) " << std::endl;
+      CHECK(0);
+    }
+    SwapInfo *target = swap_info_[victim];
+#ifdef FEGIN_DEBUG
+    std::cout << "SwapOut " << victim << " " << target->size << " "
+              << target->swap_count << std::endl;
+#endif
+    target->swap_count++;
+    memory_history_->DevHistory(device_id).num_swap_out++;
+    memory_history_->DevHistory(device_id).swap_out_total += target->size;
+    if (!infinite_memory_) {
+      if (target->cpu_address == nullptr) {
+        //target->cpu_address = new char[int(target->size)];
+        cudaHostAlloc((void**)&(target->cpu_address), target->size, 0);
+      }
+      CHECK(target->cpu_address != nullptr);
+    }
+    CHECK(target->swapped_in);
+    CHECK(!target->is_swapping.test_and_set(std::memory_order_acquire));
+    CHECK(target->dptr != nullptr);
+    target->swapped_in = false;
+    //swapinfo_groups_->SwapOut(target->dptr);
+    swappable_handles_[device_id].erase(victim);
+    divided_handles_[device_id][target->size].erase(victim);
+#ifdef FEGIN_DEBUG
+    std::cout << "Remove(1) swappable handle_id = " << victim << std::endl;
+#endif
+    thread_info_->Remove(victim);
+    pthread_rwlock_unlock(&swap_lock_);
+    if (!infinite_memory_) {
+#if 1
+      if (async) {
+        memory_manager_->MemcpyAsync(device_id, target->cpu_address,
+            target->dptr, target->size, cudaMemcpyDeviceToHost,
+            streams_out_[device_id]);
+        memory_manager_->StreamSynchronize(device_id, streams_out_[device_id]);
+      } else {
+        memory_manager_->Memcpy(device_id, target->cpu_address, target->dptr,
+            target->size, cudaMemcpyDeviceToHost);
+      }
+#endif
+    }
+    memory_manager_->Free(target->dptr, device_id);
+    pthread_rwlock_wrlock(&swap_lock_);
+    target->is_swapping.clear(std::memory_order_release);
+  }
+}
+
+// Caller holds swap_lock_
+void Swap::SwapIn(SwapInfo *info, bool async) {
+  while (info->is_swapping.test_and_set(std::memory_order_acquire)) {
+    // TODO(fegin): usleep may not be efficient and may cause unstable
+    //              execution. This is not important for now but can be
+    //              something to imporve in the future. However, this
+    //              must be designed carefully. One mutex per handle is not
+    //              acceptable unlike current atmoic variable design.
+    pthread_rwlock_unlock(&swap_lock_);
+    usleep(10);
+    pthread_rwlock_wrlock(&swap_lock_);
+  }
+  if (!info->swapped_in) {
+    CHECK(!info->swapped_in);
+    CHECK(info->cpu_address != nullptr || infinite_memory_);
+#ifdef FEGIN_DEBUG
+    std::cout << "SwapIn "<< info->handle_id << " " << info->size << " "
+              << info->swap_count << std::endl;
+#endif
+    SwapOut(info->size, info->device_id, async);
+    CHECK(memory_manager_->Malloc(info->dptr, info->size, info->device_id) ==
+          cudaSuccess);
+    pthread_rwlock_unlock(&swap_lock_);
+    memory_history_->DevHistory(info->device_id).num_swap_in++;
+    memory_history_->DevHistory(info->device_id).swap_in_total += info->size;
+    if (!infinite_memory_) {
+#if 1
+      if (async) {
+        memory_manager_->MemcpyAsync(info->device_id, info->dptr,
+            info->cpu_address, info->size, cudaMemcpyHostToDevice,
+            streams_in_[info->device_id]);
+        memory_manager_->StreamSynchronize(info->device_id,
+              streams_in_[info->device_id]);
+      } else {
+        memory_manager_->Memcpy(info->device_id, info->dptr, info->cpu_address,
+                                info->size, cudaMemcpyHostToDevice);
+      }
+#endif
+      // delete info->cpu_address;
+    }
+    // info->cpu_address = nullptr;
+    pthread_rwlock_wrlock(&swap_lock_);
+    info->swapped_in = true;
+    //swapinfo_groups_->SwapIn(info->dptr, info);
+    swappable_handles_[info->device_id].insert(info->handle_id);
+    divided_handles_[info->device_id][info->size].insert(info->handle_id);
+#ifdef FEGIN_DEBUG
+    std::cout << "Insert(1) swappable handle_id = "
+              << info->handle_id << std::endl;
+#endif
+  }
+  info->is_swapping.clear(std::memory_order_release);
+}
+
+void Swap::SetAddr(handle_id_t handle_id, void* dptr, size_t size,
+                  int device_id) {
+  if (device_id != -1) {
+    memory_history_->PutRecord(handle_id, device_id, MemoryHistory::SET_ADDR,
+                               size);
+  }
+#ifdef FEGIN_DEBUG
+  std::cout << "SetAddr=" << handle_id << ", size=" << size <<  std::endl;
+#endif
+  if (dptr == nullptr) {
+    return;
+  }
+  pthread_rwlock_wrlock(&swap_lock_);
+  auto iter = swap_info_.find(handle_id);
+  if (iter == swap_info_.end()) {
+    SwapInfo* info = new SwapInfo{handle_id, true, device_id,
+      dptr, nullptr, size, 0, ATOMIC_FLAG_INIT};
+    swap_info_[handle_id] = info;
+
+    handle_id_t ready_id = thread_info_->Access(handle_id);
+    if (ready_id != thread_info_->kInvalidID) {
+      auto ready_iter = swap_info_.find(ready_id);
+      int device_id = ready_iter->second->device_id;
+      swappable_handles_[device_id].insert(ready_id);
+      divided_handles_[device_id][ready_iter->second->size].insert(ready_id);
+#ifdef FEGIN_DEBUG
+      std::cout << "Insert(2) swappable handle_id = " << ready_id
+                << std::endl;
+#endif
+    }
+    //swapinfo_groups_->NewInfo(dptr, info);
+  } else {
+    //std::cout << "SetAddr duplicated id " << handle_id << std::endl;
+    //std::cout << "SetAddr " << iter->second->size << " " << size << std::endl;
+  }
+  pthread_rwlock_unlock(&swap_lock_);
+}
+
+void Swap::FreeAddr(handle_id_t handle_id) {
+  pthread_rwlock_wrlock(&swap_lock_);
+  //std::cout << "FreeAddr " << handle_id << std::endl;
+  auto info = swap_info_.at(handle_id);
+  if (info->device_id != -1) {
+    memory_history_->PutRecord(handle_id, info->device_id,
+                               MemoryHistory::DEL_ADDR, info->size);
+    if (swappable_handles_[info->device_id].find(handle_id)
+        != swappable_handles_[info->device_id].end()) {
+      swappable_handles_[info->device_id].erase(handle_id);
+      thread_info_->Remove(handle_id);
+    }
+    if (divided_handles_[info->device_id][info->size].find(handle_id)
+        != divided_handles_[info->device_id][info->size].end()) {
+      divided_handles_[info->device_id][info->size].erase(handle_id);
+    }
+  }
+  size_t free, total;
+  memory_manager_->MemGetInfo(info->device_id, &total, &free);
+  if (info->swapped_in) {
+    memory_manager_->Free(info->dptr, info->device_id);
+  }
+  if (info->cpu_address != nullptr) {
+    //delete info->cpu_address;
+    cudaFreeHost(info->cpu_address);
+  }
+  delete info;
+  swap_info_.erase(handle_id);
+  pthread_rwlock_unlock(&swap_lock_);
+}
+
+void Swap::DelAddr(handle_id_t handle_id) {
+  pthread_rwlock_wrlock(&swap_lock_);
+  //std::cout << "DelAddr " << handle_id << std::endl;
+  auto info = swap_info_.at(handle_id);
+  if (info->device_id != -1) {
+    memory_history_->PutRecord(handle_id, info->device_id,
+                               MemoryHistory::DEL_ADDR, info->size);
+    if (swappable_handles_[info->device_id].find(handle_id)
+        != swappable_handles_[info->device_id].end()) {
+      swappable_handles_[info->device_id].erase(handle_id);
+      thread_info_->Remove(handle_id);
+#ifdef FEGIN_DEBUG
+      std::cout << "Remove(2) swappable handle_id = " << handle_id
+                << std::endl;
+#endif
+    }
+    if (divided_handles_[info->device_id][info->size].find(handle_id)
+        != divided_handles_[info->device_id][info->size].end()) {
+      divided_handles_[info->device_id][info->size].erase(handle_id);
+    }
+  }
+  if (info->cpu_address != nullptr) {
+    //delete info->cpu_address;
+    cudaFreeHost(info->cpu_address);
+  }
+  delete info;
+  swap_info_.erase(handle_id);
+  pthread_rwlock_unlock(&swap_lock_);
+}
+
+void* Swap::GetAddr(handle_id_t handle_id, bool prefetch) {
+#ifdef FEGIN_DEBUG
+  std::cout << "GetAddr="<< handle_id << "," << std::this_thread::get_id()
+            << std::endl;
+#endif
+  pthread_rwlock_wrlock(&swap_lock_);
+  auto info = swap_info_.at(handle_id);
+  if (info->device_id != -1 && !prefetch) {
+    memory_history_->DevHistory(info->device_id).num_get_addr++;
+    memory_history_->PutRecord(handle_id, info->device_id,
+                               MemoryHistory::GET_ADDR, info->size);
+  }
+  if (!info->swapped_in) {
+    if (!prefetch) {
+      ++(memory_history_->DevHistory(info->device_id).cache_miss);
+    }
+    SwapIn(info, swap_async_);
+  }
+
+  swappable_handles_[info->device_id].erase(handle_id);
+  divided_handles_[info->device_id][info->size].erase(handle_id);
+#ifdef FEGIN_DEBUG
+  std::cout << "Remove(3) swappable handle_id = " << handle_id << std::endl;
+#endif
+
+  if (!prefetch) {
+    // Don't let the pretch thread interfere the access information.
+    handle_id_t ready_id = thread_info_->Access(handle_id);
+    if (ready_id != thread_info_->kInvalidID) {
+      auto ready_iter = swap_info_.find(ready_id);
+      int device_id = ready_iter->second->device_id;
+      swappable_handles_[device_id].insert(ready_id);
+      divided_handles_[device_id][ready_iter->second->size].insert(ready_id);
+#ifdef FEGIN_DEBUG
+      std::cout << "Insert(3) swappable handle_id = " << ready_id
+                << std::endl;
+#endif
+    }
+  }
+  pthread_rwlock_unlock(&swap_lock_);
+  return info->dptr;
+}
+
+void Swap::PrePostAccess(bool is_pre) {
+  // FIXME(fegin): If multiple thread access the same record,
+  // how are we going to handle this?
+#ifdef FEGIN_DEBUG
+  if (is_pre) {
+    std::cout << "PreAccess " << std::endl;
+  } else {
+    std::cout << "PostAccess " << std::endl;
+  }
+#endif
+  pthread_rwlock_wrlock(&swap_lock_);
+  std::set<handle_id_t>& handles =
+    thread_info_->CheckAndCreate(0, false, is_pre);
+  for (auto id : handles) {
+    auto it = swap_info_.find(id);
+    swappable_handles_[0].insert(id);
+    divided_handles_[it->second->device_id][it->second->size].insert(id);
+#ifdef FEGIN_DEBUG
+    if (is_pre) {
+      std::cout << "Insert(Pre) swappable handle_id = " << id << std::endl;
+    } else {
+      std::cout << "Insert(Post) swappable handle_id = " << id << std::endl;
+    }
+#endif
+  }
+  handles.clear();
+  pthread_rwlock_unlock(&swap_lock_);
+}
+
+void Swap::PrintHandles() {
+  std::cout << "Print Handles" << std::endl;
+  //std::map<size_t, std::unordered_set<handle_id_t> > _divided_handles_;
+  for (auto it : swap_info_) {
+    //_divided_handles_[it.second->size].insert(it.first);
+    std::cout << it.first << ": " << it.second->size << " "
+              << it.second->swap_count << " " << it.second->device_id
+              << std::endl;
+  }
+}
+
+} // namespace mxnet

--- a/src/storage/gpu_swap.cc
+++ b/src/storage/gpu_swap.cc
@@ -184,6 +184,10 @@ void Swap::SwapOutLocked(unsigned required_memory, int device_id, bool async) {
 void Swap::SwapOut(unsigned required_memory, int device_id, bool async) {
   while (!memory_manager_->TryAllocate(device_id, required_memory)) {
     SwapParams param = {0, required_memory, &divided_handles_[device_id]};
+#ifdef FEGIN_DEBUG
+    std::cout<<"Swapout calling Decide victim. Swappable size = "
+             <<swappable_handles_[device_id].size() << std::endl;
+#endif
     handle_id_t victim = memory_history_->DecideVictim(
                             swappable_handles_[device_id], device_id, &param);
     if (swap_info_.find(victim) == swap_info_.end()) {

--- a/src/storage/gpu_swap.h
+++ b/src/storage/gpu_swap.h
@@ -1,0 +1,120 @@
+#ifndef MXNET_STORAGE_SWAP_H_
+#define MXNET_STORAGE_SWAP_H_
+
+#include <atomic>
+#include <map>
+#include <memory>
+#include <pthread.h>
+#include <thread>
+#include <stack>
+#include <string>
+#include <unistd.h>
+#include <unordered_map>
+#include <queue>
+#include <set>
+#if MXNET_USE_CUDA
+#include <cuda_runtime.h>
+#endif // MXNET_USE_CUDA
+#include "./gpu_swap_history.h"
+#include "./gpu_swap_memmgr.h"
+
+namespace mxnet {
+
+struct SwapInfo {
+  handle_id_t handle_id;
+  bool swapped_in;
+  int device_id;
+  void* dptr;
+  char* cpu_address;
+  size_t size;
+  size_t swap_count;
+  std::atomic_flag is_swapping;
+};
+
+
+using SIGroup = std::vector<SwapInfo*>;
+class SwapInfoGroups {
+public:
+  ~SwapInfoGroups();
+  static SwapInfoGroups* Get();
+  static std::shared_ptr<SwapInfoGroups> _GetSharedRef();
+  void NewInfo(void* addr, SwapInfo* info);
+  std::shared_ptr<SIGroup> SwapOut(void* addr);
+  std::shared_ptr<SIGroup> SwapIn(void* addr, SwapInfo* info);
+
+private:
+  SwapInfoGroups();
+  std::unordered_map<void*, std::shared_ptr<SIGroup>> in_memory_;
+  std::unordered_map<SwapInfo*, std::shared_ptr<SIGroup>> all_;
+};
+
+class ThreadAccessInfo {
+public:
+  static const int kAccessThreshold = 0;
+  static const unsigned kInvalidID = 2147483648;
+
+  ~ThreadAccessInfo();
+  static ThreadAccessInfo* Get();
+  static std::shared_ptr<ThreadAccessInfo> _GetSharedRef();
+  std::set<handle_id_t>& CheckAndCreate(handle_id_t hid, bool access,
+                                        bool& running);
+  handle_id_t Access(handle_id_t hid);
+  void Remove(handle_id_t hid);
+
+private:
+  ThreadAccessInfo();
+  std::unordered_map<std::thread::id, std::set<handle_id_t>> all_threads_;
+  std::unordered_map<handle_id_t,
+                     std::unordered_set<std::thread::id>> hid_to_threads_;
+  std::unordered_map<std::thread::id, bool> is_running;
+  unsigned running_threshold_;
+};
+
+class Swap {
+public:
+  ~Swap();
+  static Swap* Get();
+  static std::shared_ptr<Swap> _GetSharedRef();
+  void SwapOut(unsigned required_memory, int device_id, bool async);
+  void SwapOutLocked(unsigned required_memory, int device_id, bool async);
+  void SwapIn(SwapInfo *info, bool async);
+  void SetAddr(handle_id_t handle_id, void* dptr, size_t size, int device_id);
+  void DelAddr(handle_id_t handle_id);
+  void FreeAddr(handle_id_t handle_id);
+  void* GetAddr(handle_id_t handle_id, bool prefetch = false);
+  unsigned AccessID() {
+    return access_id_.fetch_add(1, std::memory_order_relaxed);
+  }
+  void PrePostAccess(bool is_pre);
+
+#if 0
+  void LockSwap();
+  void UnlockSwap();
+#endif
+  void PrintHandles();
+
+private:
+  Swap();
+  // FIXME(fegin): The design of the following two variables doesn't support
+  // multiple GPUs.
+  std::shared_ptr<SwapInfoGroups> swapinfo_groups_;
+  std::shared_ptr<ThreadAccessInfo> thread_info_;
+  std::unordered_map<handle_id_t, SwapInfo*> swap_info_;
+  std::unordered_set<handle_id_t> swappable_handles_[NUMBER_OF_GPU];
+  std::map<size_t, std::unordered_set<handle_id_t> > divided_handles_[NUMBER_OF_GPU];
+  std::stack<handle_id_t> locked_handles_[NUMBER_OF_GPU];
+  std::vector<size_t> free_memory_;
+  std::shared_ptr<MemoryHistory> memory_history_;
+  std::shared_ptr<MemoryManager> memory_manager_;
+  std::atomic<unsigned> access_id_;
+  pthread_rwlock_t swap_lock_;
+  pthread_rwlock_t locks_[NUMBER_OF_GPU];
+  bool swap_async_;
+  bool infinite_memory_;
+  cudaStream_t streams_out_[NUMBER_OF_GPU];
+  cudaStream_t streams_in_[NUMBER_OF_GPU];
+}; // Class Swap
+
+} // namespace mxnet
+
+#endif // MXNET_STORAGE_SWAP_H_

--- a/src/storage/gpu_swap_buddy.cc
+++ b/src/storage/gpu_swap_buddy.cc
@@ -1,0 +1,198 @@
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+#include <iostream>
+#include <set>
+
+#include <dmlc/logging.h>
+#include "./gpu_swap_buddy.h"
+#include "./gpu_swap_util.h"
+
+#define BUDDY_DEBUG 0
+
+namespace mxnet {
+
+bool operator< (const Block& lhs, const Block& rhs) {
+  return (char*)lhs.data_ < (char*)rhs.data_;
+}
+
+BuddySystem::BuddySystem(void* memory, size_t size, size_t device_id)
+  : device_id_(device_id), total_size_(size), allocated_size_(0),
+    available_size_(size) {
+  free_list_size_ = ListSize(size);
+  free_list_.resize(free_list_size_);
+  memory_ = memory;
+  free_list_[free_list_size_ - 1].insert(Block(memory, size));
+}
+
+BuddySystem::~BuddySystem() {}
+
+bool BuddySystem::TryAllocate(size_t size) {
+  for (int i = AllocListIdx(size); i < free_list_size_; i++) {
+    if (free_list_[i].size() != 0) {
+      return true;
+    }
+  }
+  return false;
+}
+std::set<Block>::iterator BuddySystem::InsertBlock(const Block& block) {
+  int idx = BlockListIdx(block.Size());
+  auto ret = free_list_[idx].insert(block);
+  return ret.first;
+}
+
+void* BuddySystem::Malloc(size_t size) {
+  int list_idx = AllocListIdx(size);
+  int curr_idx = list_idx;
+
+  while (curr_idx < free_list_size_ && free_list_[curr_idx].size() == 0) {
+    curr_idx++;
+  }
+  if (curr_idx < free_list_size_) {
+    while (curr_idx > list_idx) {
+      auto victim_it = free_list_[curr_idx].begin();
+      size_t split_block_size = ListBlockSize(curr_idx - 1);
+      InsertBlock(Block(victim_it->Data(), split_block_size));
+      InsertBlock(Block((char*)victim_it->Data() + split_block_size,
+                        victim_it->Size() - split_block_size));
+      free_list_[curr_idx].erase(victim_it);
+      curr_idx--;
+    }
+    size_t block_size = ListBlockSize(list_idx);
+    auto allocated_it = free_list_[list_idx].begin();
+    if (allocated_it->Size() > block_size) {
+      InsertBlock(Block((char*)allocated_it->Data() + block_size,
+                        allocated_it->Size() - block_size));
+    }
+    allocated_size_ += block_size;
+    total_allocated_size_ += block_size;
+    available_size_ -= block_size;
+    CHECK(mem_pool_.find(allocated_it->Data()) == mem_pool_.end());
+    mem_pool_[allocated_it->Data()] = Block(allocated_it->Data(), block_size);
+    void* ret = allocated_it->Data();
+    free_list_[list_idx].erase(allocated_it);
+    return ret;
+  } else {
+    return nullptr;
+  }
+}
+
+cudaError_t BuddySystem::Free(void* ptr) {
+  auto iter = mem_pool_.find(ptr);
+  if (iter == mem_pool_.end()) {
+    CHECK(iter != mem_pool_.end());
+    return cudaErrorInvalidValue;
+  }
+  allocated_size_ -= iter->second.Size();
+  available_size_ += iter->second.Size();
+  MergeBlock(InsertBlock(iter->second), BlockListIdx(iter->second.Size()));
+  mem_pool_.erase(iter);
+#if BUDDY_DEBUG
+  CheckSize();
+#endif
+  return cudaSuccess;
+}
+
+void BuddySystem::Statistics() {
+  CheckSize();
+  std::cout << "=> BuddySystem:" << std::endl
+            << "=> Total allocated size: " << GBString(total_allocated_size_)
+            << std::endl
+            << "=> Merge count: " << merge_count_ << std::endl;
+  PrintFreeList();
+  merge_count_ = 0;
+  total_allocated_size_ = 0;
+}
+
+void BuddySystem::MergeBlock(std::set<Block>::iterator iter, int idx) {
+  size_t block_size = ListBlockSize(idx);
+  while (idx < free_list_size_ - 1) {
+    if (iter->IsLeftBlock(memory_, block_size)) {
+      auto next_iter = std::next(iter, 1);
+      if (next_iter != free_list_[idx].end() &&
+          (char*)iter->Data() + iter->Size() == (char*)next_iter->Data()) {
+        // A trick to workaround constness of std::set elements.
+        const Block &block = *iter;
+        (const_cast<Block&>(block)).SetSize(iter->Size() + next_iter->Size());
+        auto new_iter = InsertBlock(block);
+        free_list_[idx].erase(iter);
+        free_list_[idx].erase(next_iter);
+        iter = new_iter;
+      } else {
+        break;
+      }
+    } else {
+      auto prev_iter = std::prev(iter, 1);
+      if (iter != free_list_[idx].begin() &&
+          (char*)prev_iter->Data() + prev_iter->Size() == (char*)iter->Data()) {
+        // A trick to workaround constness of std::set elements.
+        const Block &block = *prev_iter;
+        (const_cast<Block&>(block)).SetSize(prev_iter->Size() + iter->Size());
+        auto new_iter = InsertBlock(block);
+        free_list_[idx].erase(prev_iter);
+        free_list_[idx].erase(iter);
+        iter = new_iter;
+      } else {
+        break;
+      }
+    }
+    merge_count_++;
+    idx += 1;
+    block_size <<= 1;
+  }
+}
+
+void BuddySystem::CheckSize() {
+  size_t size = 0;
+  for (auto& free_list : free_list_) {
+    for (auto& block : free_list) {
+      size += block.Size();
+    }
+  }
+  CHECK(size == available_size_) << "Size = " << size << " available_size = "
+                                 << available_size_;
+}
+
+void BuddySystem::CheckDuplicate() {
+#if BUDDY_DEBUG
+  std::set<void*> addr;
+  bool abort = false;
+  for (int i = 0; i < free_list_size_; i++) {
+    for (const auto& block : free_list_[i]) {
+      if (addr.find(block.Data()) != addr.end()) {
+        std::cout << "This block with address = " << block.Data()
+                  << " appeared more than once." << std::endl;
+        abort = true;
+      } else {
+        addr.insert(block.Data());
+      }
+    }
+  }
+  CHECK(!abort);
+#endif
+}
+
+void BuddySystem::PrintFreeList() {
+  std::cout << "=> Available size = " << GBString(available_size_) << std::endl;
+  for (int i = 0; i < free_list_size_; i++ ) {
+    if (free_list_[i].size() > 0) {
+      std::cout << "=> Free List Index = " << i
+                << ", size = " << free_list_[i].size() << std::endl;
+    }
+  }
+}
+
+void BuddySystem::PrintMemPool() {
+  if (mem_pool_.empty()) {
+    std::cout << "Memory pool is empty" << std::endl;
+    return;
+  }
+  std::cout << "=================================================" << std::endl
+            << "Memory Pool Info:" << std::endl
+            << "=================================================" << std::endl;
+  for (const auto& block : mem_pool_) {
+    std::cout << "Block addr = " << block.first
+              << " size = " << block.second.Size() << std::endl;
+  }
+}
+
+} //namespace mxnet

--- a/src/storage/gpu_swap_buddy.h
+++ b/src/storage/gpu_swap_buddy.h
@@ -1,0 +1,113 @@
+#ifndef MXNET_BUDDY_H_
+#define MXNET_BUDDY_H_
+
+#include <cuda_runtime_api.h>
+#include <vector>
+#include <map>
+#include <unordered_map>
+#include <set>
+
+#ifdef __GNUC__
+#define mem_likely(x)       __builtin_expect(!!(x), 1)
+#define mem_unlikely(x)     __builtin_expect(!!(x), 0)
+#else
+#define mem_likely(x)       (x)
+#define mem_unlikely(x)     (x)
+#endif
+
+namespace mxnet {
+
+class Block {
+  public:
+    Block() : data_(nullptr), size_(0) {};
+    Block(void* data, size_t size) : data_(data), size_(size) {};
+    void* Data() const { return data_; }
+    size_t Size() const { return size_; }
+    void SetSize(size_t size) { size_ = size; }
+    inline bool IsLeftBlock(const void* base, size_t block_size) const {
+      return (((size_t)data_ - (size_t)base) & block_size) == 0;
+    }
+
+    friend bool operator< (const Block& lhs, const Block& rhs);
+
+  private:
+    void* data_;
+    std::size_t size_;
+}; // Class Block
+
+static inline size_t Log2(size_t x) {
+  size_t y;
+  asm ( "\tbsr %1, %0\n"
+      : "=r"(y)
+      : "r" (x)
+  );
+  return y;
+}
+
+constexpr size_t Log2Const(size_t x) {
+  return (x <= 1) ? 0 : 1 + Log2Const(x >> 1);
+}
+
+class BuddySystem {
+  public:
+    BuddySystem(void* memory, size_t size, size_t device_id);
+    ~BuddySystem();
+    void* Memory() { return memory_; }
+    void MemoryUsage(size_t* total, size_t* free) {
+      *total = total_size_;
+      *free = available_size_;
+    }
+    bool TryAllocate(size_t size);
+    void* Malloc(size_t size);
+    cudaError_t Free(void* ptr);
+    void Statistics();
+
+  private:
+    static const size_t kMinAllocateSize = 1;
+    static constexpr size_t kLogBase = Log2Const(kMinAllocateSize);
+    static inline size_t AllocListIdx(size_t size) {
+      if (mem_unlikely(size <= kMinAllocateSize)) {
+        return 0;
+      } else {
+        size_t size_log = Log2(size);
+        size_log += ((1 << size_log) ^ size) ? 1 : 0;
+        return size_log - kLogBase;
+      }
+    }
+    static inline size_t BlockListIdx(size_t size) {
+      if (mem_unlikely(size <= kMinAllocateSize)) {
+        return 0;
+      } else {
+        return Log2(size) - kLogBase;
+      }
+    }
+    static inline size_t ListSize(size_t size) {
+      return BlockListIdx(size) + 1;
+    }
+    static inline size_t ListBlockSize(int idx) {
+      return 1L << (idx + kLogBase);
+    }
+
+    std::set<Block>::iterator InsertBlock(const Block& block);
+    void MergeBlock(std::set<Block>::iterator iter, int idx);
+    void PrintFreeList();
+    void PrintMemPool();
+    void CheckDuplicate();
+    void CheckSize();
+
+    size_t device_id_;
+    void* memory_;
+    std::unordered_map<void*, Block> mem_pool_;
+    std::vector<std::set<Block>> free_list_;
+    int free_list_size_;
+    size_t total_size_;
+    size_t allocated_size_;
+    size_t available_size_;
+    size_t total_allocated_size_;
+    size_t merge_count_;
+}; //Class BuddySystem
+
+} //namespace mxnet
+
+#endif // MXNET_BUDDY_H_
+

--- a/src/storage/gpu_swap_history.cc
+++ b/src/storage/gpu_swap_history.cc
@@ -241,6 +241,10 @@ void MemoryHistory::PrintRecord(int device) {
 }
 
 void MemoryHistory::StartIteration() {
+  if(dmlc::GetEnv("MXNET_GPU_MEM_POOL_TYPE", std::string("Naive"))
+     != "OnDemandSwap") {
+    return;
+  }
   iteration_started_ = true;
   for (int i = 0; i < NUMBER_OF_GPU; i++) {
     dev_history_[i].curr_idx = 0;
@@ -304,6 +308,10 @@ void MemoryHistory::StartIteration() {
 }
 
 void MemoryHistory::StopIteration() {
+  if(dmlc::GetEnv("MXNET_GPU_MEM_POOL_TYPE", std::string("Naive"))
+     != "OnDemandSwap") {
+    return;
+  }
   pre_recording_ = false;
   is_recording_ = false;
   iteration_started_ = false;

--- a/src/storage/gpu_swap_history.cc
+++ b/src/storage/gpu_swap_history.cc
@@ -1,0 +1,399 @@
+#include <algorithm>
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <list>
+#include <unistd.h>
+#include <unordered_set>
+#include <vector>
+#include <set>
+#include <dmlc/parameter.h>
+#include <dmlc/logging.h>
+#include "./gpu_swap_history.h"
+#include "./gpu_swap_prefetch.h"
+#include "./gpu_swap_memmgr.h"
+#include "./gpu_swap_util.h"
+
+namespace mxnet {
+
+MemoryHistory::MemoryHistory() {
+  iteration_started_ = false;
+  is_recording_ = false;
+  pre_recording_ = false;
+  iteration_idx_ = 0;
+  swap_algorithm_ = dmlc::GetEnv("MXNET_SWAP_ALGORITHM", std::string("LRU"));
+  adaptive_history_ = dmlc::GetEnv("MXNET_ADAPTIVE_HISTORY", false);
+  bool infinite_memory = dmlc::GetEnv("MXNET_INFINITE_MEMORY", false);
+  if (infinite_memory) {
+      swap_algorithm_ = "SizeHistory";
+  }
+  dev_history_.resize(NUMBER_OF_GPU);
+  std::cout << "Swap Algorithm: " << swap_algorithm_ << std::endl;
+  if (swap_algorithm_ == "LRU") {
+    DoDecide = &MemoryHistory::LRU;
+  } else if (swap_algorithm_ == "NaiveHistory") {
+    DoDecide = &MemoryHistory::NaiveHistory;
+  } else if (swap_algorithm_ == "SizeHistory") {
+    DoDecide = &MemoryHistory::SizeHistory;
+  } else {
+    std::cout << "Unknown Algorithm Name: " << swap_algorithm_ << std::endl;
+    CHECK(0);
+  }
+}
+
+MemoryHistory::~MemoryHistory() {}
+
+std::shared_ptr<MemoryHistory> MemoryHistory::_GetSharedRef() {
+  static std::shared_ptr<MemoryHistory> inst(new MemoryHistory());
+  return inst;
+}
+
+MemoryHistory* MemoryHistory::Get() {
+  static MemoryHistory *s = _GetSharedRef().get();
+  return s;
+}
+
+void MemoryHistory::PreRecord(handle_id_t handle_id, record_t op,
+                              DeviceHistory& history) {
+  if (op == MemoryHistory::SET_ADDR) {
+    history.lru_list.push_front(handle_id);
+    history.lru_map[handle_id] = history.lru_list.begin();
+  } else if (op == MemoryHistory::GET_ADDR) {
+    if (history.lru_map[handle_id] == history.lru_list.end()) {
+      history.lru_list.push_front(handle_id);
+      history.lru_map[handle_id] = history.lru_list.begin();
+    } else {
+      std::list<handle_id_t>::iterator hid = history.lru_map[handle_id];
+      history.lru_list.erase(hid);
+      history.lru_list.push_front(handle_id);
+      history.lru_map[handle_id] = history.lru_list.begin();
+    }
+  } else {
+    std::list<handle_id_t>::iterator hid = history.lru_map[handle_id];
+    history.lru_list.erase(hid);
+    history.lru_map.erase(handle_id);
+  }
+}
+
+void MemoryHistory::PutRecord(handle_id_t handle_id, int device,
+                              record_t op, size_t size) {
+  if (!IterationStarted()) {
+    return;
+  }
+  auto& history = dev_history_[device];
+  if (IsPreRecording()) {
+    std::lock_guard<std::mutex> lock(mutex_[device]);
+    MemoryHistory::PreRecord(handle_id, op, history);
+  }
+  if (IsRecording()) {
+    std::lock_guard<std::mutex> lock(mutex_[device]);
+    timestamp_t t = (duration_cast<microseconds>
+        (high_resolution_clock::now() - begin_time_)).count();
+    size_t record_step = history.curr_idx;
+    MemRecord record = {handle_id, op, t, record_step, size};
+    history.all_handle_history.back()[handle_id].push_back(record);
+    history.all_ordered_history.back().push_back(record);
+  }
+  history.curr_idx++;
+}
+
+// LRU: Swapout the least recently used handle
+handle_id_t MemoryHistory::LRU(std::unordered_set<handle_id_t> handles,
+                               int device, void* arg) {
+  auto& history = dev_history_[device];
+  handle_id_t victim = -1;
+  while (history.lru_list.size() != 0 &&
+    handles.find(history.lru_list.back()) == handles.end()) {
+    handle_id_t temp_id = history.lru_list.back();
+    history.lru_map[temp_id] = history.lru_list.end();
+    history.lru_list.pop_back();
+  }
+  if (history.lru_list.size() == 0) {
+    std::cout << "LRU: No Swappable Handle Found" << std::endl;
+    CHECK(0);
+  } else {
+    victim = history.lru_list.back();
+    history.lru_map[victim] = history.lru_list.end();
+    history.lru_list.pop_back();
+  }
+  return victim;
+}
+
+// NaiveHistory: assume iterations remain the same; choose the handle
+// whose next reference is furthest in the future as victim.
+handle_id_t MemoryHistory::NaiveHistory(
+  std::unordered_set<handle_id_t> handles, int device, void* arg) {
+  auto& history = dev_history_[device];
+  SwapParams* params = (SwapParams*)arg;
+  size_t latest_step = 0;
+  handle_id_t latest_id = 0;
+  for (auto &id : handles) {
+    MemoryHistory::MemRecord r = {0, MemoryHistory::GET_ADDR, 0,
+                               history.curr_idx, 0};
+    auto it = std::upper_bound(history.handle_history->at(id).begin(),
+                               history.handle_history->at(id).end(), r,
+                               CompareByStep);
+    if (it == history.handle_history->at(id).end()) {
+      /*
+      if (it != history.handle_history->at(id).begin() &&
+          history.curr_idx - history.handle_history->at(id).back().record_step < 10) {
+        // Victim just used, skip
+        continue;
+      }
+      */
+      return id;
+    } else if (it->record_step - history.curr_idx < params->no_swap_steps) {
+      continue;
+    } else if (it->record_step > latest_step) {
+      latest_step = it->record_step;
+      latest_id = id;
+    }
+  }
+  return latest_id;
+}
+
+handle_id_t MemoryHistory::SizeHistory(
+    std::unordered_set<handle_id_t> handles, int device, void* arg) {
+  auto divided_handles  = ((SwapParams*)arg)->divided_handles;
+  auto candidates = divided_handles->lower_bound(((SwapParams*)arg)->required_memory);
+  auto original_candidates = candidates;
+  bool reverse_flag = false;
+  //FIXME: Empirical result may need a better way to know how to choose this.
+  size_t no_swap_step = 80;
+  if (candidates == divided_handles->end()) {
+    candidates--;
+  }
+  while (true) {
+    if (candidates->second.size() != 0) {
+      SwapParams new_params = {no_swap_step, 0, nullptr};
+      handle_id_t victim = NaiveHistory(candidates->second, device, &new_params);
+      if (victim != 0) {
+        return victim;
+      }
+    }
+    if (!reverse_flag) {
+      candidates++;
+      if (candidates == divided_handles->end()) {
+        candidates = original_candidates;
+        reverse_flag = true;
+      }
+    }
+    if (reverse_flag) {
+      if (candidates == divided_handles->begin()) {
+        candidates = original_candidates;
+        reverse_flag = false;
+        if (no_swap_step == 0) {
+          std::cout << "Cannot find victim (algorithm error)" << std::endl;
+          CHECK(0);
+        }
+        no_swap_step /= 2;
+      } else {
+        candidates --;
+      }
+    }
+  }
+  return 0;
+}
+
+handle_id_t MemoryHistory::DecideVictim(std::unordered_set<handle_id_t> handles,
+                                        int device, void* arg) {
+  std::lock_guard<std::mutex> lock(mutex_[device]);
+  if (iteration_idx_ <= kBeginRecordAt) {
+    return MemoryHistory::LRU(handles, device, nullptr);
+  } else {
+    return (this->*DoDecide)(handles, device, arg);
+  }
+}
+
+void MemoryHistory::PrintRecord(int device) {
+  std::lock_guard<std::mutex> lock(mutex_[device]);
+  auto& history = dev_history_[device];
+  std::ofstream fp;
+  fp.open("history_log.txt");
+  std::vector<MemRecord> records;
+  std::map<handle_id_t, std::vector<MemRecord> >::iterator it;
+  for (it = history.handle_history->begin();
+       it != history.handle_history->end(); ++it) {
+    for (size_t i = 0; i < (it->second).size(); i++) {
+      records.push_back(it->second[i]);
+    }
+  }
+  std::sort(records.begin(), records.end(), MemoryHistory::CompareByStep);
+  for (size_t i = 0; i < records.size(); i++) {
+    MemRecord r = records[i];
+    fp << "No." << i << std::endl;
+    fp << "Step: " << r.record_step << std::endl;
+    fp << "Handle ID: " << r.handle_id << std::endl;
+    fp << "Operation: ";
+    if (r.operation_id == GET_ADDR) {
+      fp << "get";
+    } else if (r.operation_id == SET_ADDR) {
+      fp << "set";
+    } else {
+      fp << "del";
+    }
+    fp << std::endl;
+    fp << "Time: " << r.time << std::endl;
+    fp << "Size: " << r.size << std::endl;
+    fp << std::endl;
+  }
+  fp.close();
+}
+
+void MemoryHistory::StartIteration() {
+  iteration_started_ = true;
+  for (int i = 0; i < NUMBER_OF_GPU; i++) {
+    dev_history_[i].curr_idx = 0;
+  }
+  // LRU needs to record every iteration. As a result, it is mandatory to do LRU
+  // recording even at kBeginRecordAt iteration because the desired swapping
+  // algorithm will kick in from (kBeginRecordAt + 1) iteration.
+  if (iteration_idx_ <= kBeginRecordAt || swap_algorithm_ == "LRU") {
+    pre_recording_ = true;
+  }
+  if ((adaptive_history_ && iteration_idx_ >= kBeginRecordAt) ||
+      iteration_idx_ == kBeginRecordAt) {
+    // Each history is stored in a cyclic list (mimiced by std::list).
+    // The LAST history in a cyclic list is used to be recorded in current
+    // iteration. The (LAST-1) history is used by DoDecide(). However, if
+    // adaptive_history_ is false, The LAST history is used by DoDecide().
+    for (int i = 0; i < NUMBER_OF_GPU; i++) {
+      auto& history = dev_history_[i];
+      if (history.all_ordered_history.size() ==
+          DeviceHistory::kMaxPreservedIteration) {
+        history.all_ordered_history.splice(history.all_ordered_history.end(),
+                                           history.all_ordered_history,
+                                           history.all_ordered_history.begin());
+        history.all_handle_history.splice(history.all_handle_history.end(),
+                                          history.all_handle_history,
+                                          history.all_handle_history.begin());
+      } else {
+        size_t size = history.all_ordered_history.size();
+        history.all_ordered_history.resize(size + 1);
+        history.all_handle_history.resize(size + 1);
+      }
+      auto ordered_it = history.all_ordered_history.rbegin();
+      auto handle_it  = history.all_handle_history.rbegin();
+      if (history.all_ordered_history.size() > 1) {
+        ordered_it = std::next(ordered_it, 1);
+        handle_it = std::next(handle_it, 1);
+      }
+      history.ordered_history = &(*ordered_it);
+      history.handle_history = &(*handle_it);
+      history.all_ordered_history.rbegin()->clear();
+      history.all_handle_history.rbegin()->clear();
+    }
+    is_recording_ = true;
+  }
+  begin_time_ = high_resolution_clock::now();
+  for (int device = 0; device < NUMBER_OF_GPU; device++) {
+    dev_history_[device].prefetch_count = 0;
+    dev_history_[device].cache_miss = 0;
+    dev_history_[device].num_swap_in = 0;
+    dev_history_[device].num_swap_out = 0;
+    dev_history_[device].swap_in_total = 0;
+    dev_history_[device].swap_out_total = 0;
+    dev_history_[device].num_get_addr = 0;
+  }
+
+  // We can't start the prefetching too early, otherwise, the prefetch_count
+  // may be incorrect.
+  if (iteration_idx_ > kBeginRecordAt) {
+    Prefetch::Get()->StartPrefetching();
+  }
+}
+
+void MemoryHistory::StopIteration() {
+  pre_recording_ = false;
+  is_recording_ = false;
+  iteration_started_ = false;
+  if (Prefetch::Get()->IsPrefetching()) {
+    Prefetch::Get()->StopPrefetching();
+  }
+  ++iteration_idx_;
+  //for (int device = 0; device < NUMBER_OF_GPU; device++) {
+    //auto& history = dev_history_[device];
+    //if (adaptive_history_ && iteration_started_ >= kBeginRecordAt) {
+      //history.all_ordered_history.push_back(history.ordered_history);
+      //history.all_handle_history.push_back(history.handle_history);
+    //}
+  //}
+}
+
+void MemoryHistory::Statistics() {
+  if (adaptive_history_) {
+    PrintSimilarity();
+  }
+  for (int device = 0; device < NUMBER_OF_GPU; device++) {
+    auto& history = dev_history_[device];
+    std::cout << "GPU" << device << " statistics:" << std::endl
+              << "=> Number of prefetch: "
+              << history.prefetch_count << std::endl
+              << "=> Number of cache miss: "
+              << history.cache_miss << std::endl
+              << "=> Number of getaddr: "
+              << history.num_get_addr << std::endl
+              << "=> Number of swap in: "
+              << history.num_swap_in << std::endl
+              << "=> Total swap in size: "
+              << GBString(history.swap_in_total) << std::endl
+              << "=> Number of swap out: "
+              << history.num_swap_out << std::endl
+              << "=> Total swap out size: "
+              << GBString(history.swap_out_total)<< std::endl;
+  }
+  GetMemoryManager()->Statistics();
+}
+
+double MemoryHistory::LCS_Similarity(std::vector<MemRecord>& base,
+                                     std::vector<MemRecord>& target) {
+  std::vector<size_t> *prev_table, *curr_table, *temp;
+  size_t size1 = base.size();
+  size_t size2 = target.size();
+  prev_table = new std::vector<size_t>(size2 + 1, 0);
+  curr_table = new std::vector<size_t>(size2 + 1, 0);
+  for (size_t i = 1; i <= size1; i++) {
+    for (size_t j = 1; j <= size2; j++) {
+      if (base[i - 1].handle_id == target[j - 1].handle_id) {
+        (*curr_table)[j] = (*prev_table)[j - 1] + 1;
+      } else {
+        (*curr_table)[j] = std::max((*curr_table)[j - 1], (*prev_table)[j]);
+      }
+    }
+    temp = curr_table;
+    curr_table = prev_table;
+    prev_table = temp;
+  }
+  return (*prev_table)[size2] / (double)std::max(size1, size2);
+}
+
+void MemoryHistory::PrintSimilarity() {
+  double min = 1.0, max = 0.0, mean = 0.0, delta = 0.0, delta2 = 0.0, M2 = 0.0;
+  int count = 0;
+  if (dev_history_[0].all_ordered_history.size() < kBeginRecordAt) {
+    return;
+  }
+  for (int device = 0; device < NUMBER_OF_GPU; device++) {
+    std::cout << "GPU" << device << " history similarity:" << std::endl;
+    auto& history = dev_history_[device];
+    for (size_t i = 0; i < history.all_ordered_history.size() - 1; i++) {
+      auto base_it = std::next(history.all_ordered_history.begin(), i);
+      auto target_it = std::next(base_it, 1);
+      while (target_it != history.all_ordered_history.end()) {
+        double sim = LCS_Similarity(*base_it, *target_it);
+        min = (sim < min) ? sim : min;
+        max = (sim > max) ? sim : max;
+        count += 1;
+        delta = sim - mean;
+        mean = mean + delta / count;
+        delta2 = sim - mean;
+        M2 += delta * delta2;
+        target_it++;
+      }
+    }
+  }
+  std::cout << "min: " << min << ", max: " << max << ", mean: " << mean << " " << M2
+            << " stddev: " << sqrt(M2 / count - 1) << std::endl;
+}
+
+} // namespace mxnet

--- a/src/storage/gpu_swap_history.cc
+++ b/src/storage/gpu_swap_history.cc
@@ -124,6 +124,10 @@ handle_id_t MemoryHistory::LRU(std::unordered_set<handle_id_t> handles,
 handle_id_t MemoryHistory::NaiveHistory(
   std::unordered_set<handle_id_t> handles, int device, void* arg) {
   auto& history = dev_history_[device];
+#ifdef FEGIN_DEBUG
+  std::cout << "DoDecide: NaiveHistory, handles numbers = " 
+            << history.handle_history.size() << std::endl;
+#endif
   SwapParams* params = (SwapParams*)arg;
   size_t latest_step = 0;
   handle_id_t latest_id = 0;
@@ -242,7 +246,7 @@ void MemoryHistory::PrintRecord(int device) {
 
 void MemoryHistory::StartIteration() {
   if(dmlc::GetEnv("MXNET_GPU_MEM_POOL_TYPE", std::string("Naive"))
-     != "OnDemandSwap") {
+     != "SwapOnDemand") {
     return;
   }
   iteration_started_ = true;
@@ -309,7 +313,7 @@ void MemoryHistory::StartIteration() {
 
 void MemoryHistory::StopIteration() {
   if(dmlc::GetEnv("MXNET_GPU_MEM_POOL_TYPE", std::string("Naive"))
-     != "OnDemandSwap") {
+     != "SwapOnDemand") {
     return;
   }
   pre_recording_ = false;

--- a/src/storage/gpu_swap_history.h
+++ b/src/storage/gpu_swap_history.h
@@ -1,0 +1,109 @@
+#ifndef GPU_SWAP_HISTORY_H_
+#define GPU_SWAP_HISTORY_H_
+
+#include <chrono>
+#include <map>
+#include <unordered_map>
+#include <unordered_set>
+#include <list>
+#include <vector>
+#include <thread>
+#include <mutex>
+
+#if MXNET_USE_CUDA
+#include <cuda_runtime.h>
+#endif
+
+using namespace std::chrono;
+
+namespace mxnet {
+
+using handle_id_t = unsigned long long;
+using timestamp_t = unsigned long long;
+using timestep_t = unsigned long long;
+
+const int NUMBER_OF_GPU = 1;
+
+struct SwapParams {
+  size_t no_swap_steps;
+  size_t required_memory;
+  std::map<size_t, std::unordered_set<handle_id_t> >* divided_handles;
+};
+
+class MemoryHistory {
+public:
+  enum record_t {GET_ADDR, SET_ADDR, DEL_ADDR};
+  struct MemRecord {
+    handle_id_t handle_id;
+    record_t operation_id;
+    timestamp_t time;
+    size_t record_step;
+    size_t size;
+  };
+  struct DeviceHistory {
+    static const size_t kMaxPreservedIteration = 10;
+    std::list<std::map<handle_id_t, std::vector<MemRecord>>> all_handle_history;
+    std::map<handle_id_t, std::vector<MemRecord>> *handle_history;
+    std::list<std::vector<MemRecord>> all_ordered_history;
+    std::vector<MemRecord> *ordered_history;
+    std::list<handle_id_t> lru_list;
+    std::unordered_map<handle_id_t, std::list<handle_id_t>::iterator> lru_map;
+    size_t curr_idx;
+    // Statistics
+    size_t prefetch_count;
+    size_t cache_miss;
+    size_t num_swap_in;
+    size_t num_swap_out;
+    size_t swap_in_total;
+    size_t swap_out_total;
+    size_t num_get_addr;
+  };
+  static const size_t kBeginRecordAt = 2;
+
+  ~MemoryHistory();
+  static bool CompareByStep(const MemRecord &r1, const MemRecord &r2) {
+    return r1.record_step < r2.record_step;
+  }
+  static MemoryHistory* Get();
+  static std::shared_ptr<MemoryHistory> _GetSharedRef();
+  bool IterationStarted() {return iteration_started_;}
+  bool IsPreRecording() {return pre_recording_;}
+  bool IsRecording() {return is_recording_;}
+  DeviceHistory& DevHistory(int device) {return dev_history_[device];}
+  size_t GetIterationIdx() {return iteration_idx_;}
+  void PreRecord(handle_id_t handle_id, record_t op, DeviceHistory& history);
+  void PutRecord(handle_id_t handle_id, int device, record_t op, size_t size);
+  void PrintRecord(int device);
+  void StartIteration();
+  void StopIteration();
+  void Statistics();
+  handle_id_t DecideVictim(std::unordered_set<handle_id_t> handles, int device,
+                           void* arg);
+
+private:
+  MemoryHistory();
+  std::vector<std::mutex> mutex_ = std::vector<std::mutex>(NUMBER_OF_GPU);
+  handle_id_t (MemoryHistory::*DoDecide)(std::unordered_set<handle_id_t>, int, void*);
+  void PrintSimilarity();
+  double LCS_Similarity(std::vector<MemRecord>& base,
+                        std::vector<MemRecord>& target);
+  // Swap algorithm declaration
+  handle_id_t LRU(std::unordered_set<handle_id_t> handles, int device, void* arg);
+  handle_id_t NaiveHistory(std::unordered_set<handle_id_t> handles, int device,
+      void* arg);
+  handle_id_t SizeHistory(std::unordered_set<handle_id_t> handles, int device,
+      void* arg);
+
+  std::vector<DeviceHistory> dev_history_;
+  bool iteration_started_;
+  bool is_recording_;
+  bool pre_recording_;
+  size_t iteration_idx_;
+  bool adaptive_history_;
+  std::string swap_algorithm_;
+  high_resolution_clock::time_point begin_time_;
+};  // class MemoryHistory
+
+} // namespace mxnet
+
+#endif

--- a/src/storage/gpu_swap_memmgr.cc
+++ b/src/storage/gpu_swap_memmgr.cc
@@ -1,0 +1,331 @@
+#include <assert.h>
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+#include <dmlc/parameter.h>
+#include <dmlc/logging.h>
+#include <thread>
+#include <math.h>
+
+#include "../common/cuda_utils.h"
+#include "./gpu_swap_memmgr.h"
+#include "./gpu_swap_util.h"
+
+namespace mxnet {
+
+#define CUDA_CALL(func) {                                   \
+  cudaError_t e = (func);                                   \
+  CHECK(e == cudaSuccess || e == cudaErrorCudartUnloading)  \
+        << __FUNCTION__ << ":" << __LINE__                  \
+        << " (tid = " << std::this_thread::get_id() << ")"  \
+        << " has a CUDA error: " << cudaGetErrorString(e);  \
+}
+
+cudaError_t MemoryManager::Memcpy(int device_id, void* dst, const void* src,
+                                  size_t count, enum cudaMemcpyKind kind) {
+  CUDA_CALL(cudaSetDevice(device_id));
+  CUDA_CALL(cudaMemcpy(dst, src, count, kind));
+  return cudaSuccess;
+}
+
+cudaError_t MemoryManager::MemcpyAsync(
+        int device_id, void* dst, const void* src, size_t count,
+        cudaMemcpyKind kind, cudaStream_t stream) {
+  CUDA_CALL(cudaSetDevice(device_id));
+  CUDA_CALL(cudaMemcpyAsync(dst, src, count, kind, stream));
+  return cudaSuccess;
+}
+
+cudaError_t MemoryManager::StreamSynchronize(int device_id,
+                                             cudaStream_t stream) {
+  CUDA_CALL(cudaSetDevice(device_id));
+  CUDA_CALL(cudaStreamSynchronize(stream));
+  return cudaSuccess;
+}
+
+cudaError_t MemoryManager::Malloc(void*& devptr, size_t size, int device_id) {
+  malloc_count_[device_id]++;
+  malloc_size_[device_id] += size;
+  malloc_type_[device_id][size] += 1;
+  return this->MallocInternal(devptr, size, device_id);
+}
+
+cudaError_t MemoryManager::Free(void* devptr, int device_id) {
+  free_count_[device_id]++;
+  return this->FreeInternal(devptr, device_id);
+}
+
+void MemoryManager::Statistics() {
+  for (int i = 0; i < NUMBER_OF_GPU; i++) {
+    std::cout << "MemoryManager " << i << " Statistics:" << std::endl
+              << "=> Malloc count: " << malloc_count_[i] << std::endl
+              << "=> Malloc size: " << GBString(malloc_size_[i]) << std::endl
+              << "=> Malloc type: " << malloc_type_[i].size() << std::endl
+              << "=> Free count: " << free_count_[i] << std::endl;
+    malloc_count_[i] = malloc_size_[i] = free_count_[i] = 0;
+  }
+  this->StatisticsInternal();
+}
+
+CudaMemoryManager::CudaMemoryManager() {
+  std::cout << "Initialize CUDA Memory Allocator" << std::endl;
+}
+
+CudaMemoryManager::~CudaMemoryManager() {
+  std::cout << "Destroy Cuda Memory Allocator" << std::endl;
+}
+
+cudaError_t CudaMemoryManager::MemGetInfo(int device_id, size_t* total,
+                                          size_t* free) {
+  CUDA_CALL(cudaSetDevice(device_id));
+  CUDA_CALL(cudaMemGetInfo(free, total));
+  return cudaSuccess;
+}
+
+bool CudaMemoryManager::TryAllocate(int device_id, size_t size) {
+  CUDA_CALL(cudaSetDevice(device_id));
+  size_t free, total;
+  CUDA_CALL(cudaMemGetInfo(&free, &total));
+  // TODO(fegin): This fixed threshold is not acceptable.
+  // FIXME(fegin): The maximum threshould I used in the old MXNet is 512 MB.
+  //               We should figure out why such a large threshold is needed
+  //               for current implementation.
+  return free > size + 1500000000;
+}
+
+cudaError_t CudaMemoryManager::MallocInternal(void*& devptr, size_t size,
+                                              int device_id) {
+  CUDA_CALL(cudaSetDevice(device_id));
+  CUDA_CALL(cudaMalloc(&devptr, size));
+  return cudaSuccess;
+}
+
+cudaError_t CudaMemoryManager::FreeInternal(void* devptr, int device_id) {
+  CUDA_CALL(cudaSetDevice(device_id));
+  CUDA_CALL(cudaFree(devptr));
+  return cudaSuccess;
+}
+
+void CudaMemoryManager::StatisticsInternal() {
+}
+
+BuddyMemoryManager::BuddyMemoryManager() {
+  std::cout << "Initializing Memory Manager" << std::endl;
+  buddy_.resize(NUMBER_OF_GPU);
+  for (size_t device = 0; device < NUMBER_OF_GPU; device++) {
+    size_t avail, total;
+    CUDA_CALL(cudaSetDevice(device));
+    CUDA_CALL(cudaMemGetInfo(&avail, &total));
+    bool infinite_memory = dmlc::GetEnv("MXNET_INFINITE_MEMORY", false);
+    if (infinite_memory) {
+        avail = static_cast<size_t>(avail * 0.8);
+    } else {
+        float ratio = dmlc::GetEnv("MXNET_GPU_UTIL_RATIO", kGPUUtilRatio);
+        avail = static_cast<size_t>(avail * ratio);
+    }
+    void* memory = nullptr;
+    while (cudaMalloc((void**)&memory, avail) == cudaErrorMemoryAllocation) {
+      avail -= kMB;
+      if (avail == 0) {
+        break;
+      }
+    }
+    CHECK(avail > 0);
+    buddy_[device] = new BuddySystem(memory, avail, device);
+    std::cout << "Buddy System No." << device << " initialized with size = "
+              << GBString(avail) << std::endl;
+  }
+  std::cout << "Memory Manager initialization completed" << std::endl;
+}
+
+BuddyMemoryManager::~BuddyMemoryManager() {
+  for (size_t device = 0; device < NUMBER_OF_GPU; device++) {
+    CUDA_CALL(cudaSetDevice(device));
+    CUDA_CALL(cudaFree((void*)(buddy_[device]->Memory())));
+    delete buddy_[device];
+    buddy_[device] = nullptr;
+    std::cout << "Buddy System No." << device << " destructed" << std::endl;
+  }
+}
+
+cudaError_t BuddyMemoryManager::MemGetInfo(int device_id, size_t* total,
+                                           size_t* free) {
+  std::lock_guard<std::mutex> lock(mutex_[device_id]);
+  buddy_[device_id]->MemoryUsage(total, free);
+  return cudaSuccess;
+}
+
+bool BuddyMemoryManager::TryAllocate(int device_id, size_t size) {
+  std::lock_guard<std::mutex> lock(mutex_[device_id]);
+  return buddy_[device_id]->TryAllocate(size);
+}
+
+cudaError_t BuddyMemoryManager::MallocInternal(void*& devptr, size_t size,
+                                               int device_id) {
+  std::lock_guard<std::mutex> lock(mutex_[device_id]);
+  devptr = buddy_[device_id]->Malloc(size);
+  return (devptr) ? cudaSuccess : cudaErrorMemoryAllocation;
+}
+
+cudaError_t BuddyMemoryManager::FreeInternal(void* devptr, int device_id) {
+  std::lock_guard<std::mutex> lock(mutex_[device_id]);
+  buddy_[device_id]->Free(devptr);
+  return cudaSuccess;
+}
+
+void BuddyMemoryManager::StatisticsInternal() {
+  for (int i = 0; i < NUMBER_OF_GPU; i++) {
+    buddy_[i]->Statistics();
+  }
+}
+
+FakeMemoryManager::FakeMemoryManager() {
+  std::cout << "Initializing Fake Memory Manager" << std::endl;
+  ptrs_.resize(NUMBER_OF_GPU);
+  for (size_t device = 0; device < NUMBER_OF_GPU; device++) {
+    size_t avail, total;
+    CUDA_CALL(cudaSetDevice(device));
+    CUDA_CALL(cudaMemGetInfo(&avail, &total));
+    float ratio = dmlc::GetEnv("MXNET_GPU_UTIL_RATIO", kGPUUtilRatio);
+    avail = static_cast<size_t>(avail * ratio);
+    void* memory = nullptr;
+    while (cudaMalloc((void**)&memory, avail) == cudaErrorMemoryAllocation) {
+      avail -= kMB;
+      if (avail == 0) {
+        break;
+      }
+    }
+    CHECK(avail > 0);
+    ptrs_[device] = memory;
+    std::cout << "Fake system No." << device << " initialized with size = "
+              << GBString(avail) << std::endl;
+  }
+  std::cout << "Fake Memory Manager initialization completed" << std::endl;
+}
+
+FakeMemoryManager::~FakeMemoryManager() {
+  for (size_t device = 0; device < NUMBER_OF_GPU; device++) {
+    CUDA_CALL(cudaSetDevice(device));
+    CUDA_CALL(cudaFree((void*)ptrs_[device]));
+    ptrs_[device] = nullptr;
+    std::cout << "Fake system No." << device << " destructed" << std::endl;
+  }
+  std::cout << "Destroy Fake Memory Allocator" << std::endl;
+}
+
+cudaError_t FakeMemoryManager::MemGetInfo(int device_id, size_t* total,
+                                          size_t* free) {
+  *total = ~1;
+  *free = ~1;
+  return cudaSuccess;
+}
+
+bool FakeMemoryManager::TryAllocate(int device_id, size_t size) {
+  return true;
+}
+
+cudaError_t FakeMemoryManager::MallocInternal(void*& devptr, size_t size,
+                                              int device_id) {
+  devptr = ptrs_[device_id];
+  return cudaSuccess;
+}
+
+cudaError_t FakeMemoryManager::FreeInternal(void* devptr, int device_id) {
+  return cudaSuccess;
+}
+
+void FakeMemoryManager::StatisticsInternal() {
+}
+
+/*
+SlabMemoryManager::SlabMemoryManager() {
+  std::cout << "Initializing Memory Manager" << std::endl;
+  buddy_.resize(NUMBER_OF_GPU);
+  for (size_t device = 0; device < NUMBER_OF_GPU; device++) {
+    size_t avail, total;
+    CUDA_CALL(cudaSetDevice(device));
+    CUDA_CALL(cudaMemGetInfo(&avail, &total));
+    float ratio = dmlc::GetEnv("MXNET_GPU_UTIL_RATIO", kGPUUtilRatio);
+    avail = static_cast<size_t>(avail * ratio);
+    void* memory = nullptr;
+    while (cudaMalloc((void**)&memory, avail) == cudaErrorMemoryAllocation) {
+      avail -= kMB;
+      if (avail == 0) {
+        break;
+      }
+    }
+    CHECK(avail > 0);
+    buddy_[device] = new SlabSystem(memory, avail, device);
+    std::cout << "Slab System No." << device << " initialized with size = "
+              << avail << " bytes" << std::endl;
+  }
+  std::cout << "Memory Manager initialization completed" << std::endl;
+}
+
+SlabMemoryManager::~SlabMemoryManager() {
+  for (size_t device = 0; device < NUMBER_OF_GPU; device++) {
+    CUDA_CALL(cudaSetDevice(device));
+    CUDA_CALL(cudaFree((void*)(buddy_[device]->Memory())));
+    delete buddy_[device];
+    buddy_[device] = nullptr;
+    std::cout << "Slab System No." << device << " destructed" << std::endl;
+  }
+}
+
+cudaError_t SlabMemoryManager::Malloc(void*& devptr, size_t size,
+                                       int device_id) {
+  std::lock_guard<std::mutex> lock(mutex_[device_id]);
+  devptr = buddy_[device_id]->Malloc(size);
+  return (devptr) ? cudaSuccess : cudaErrorMemoryAllocation;
+}
+
+cudaError_t SlabMemoryManager::Free(void* devptr, int device_id) {
+  std::lock_guard<std::mutex> lock(mutex_[device_id]);
+  buddy_[device_id]->Free(devptr);
+  return cudaSuccess;
+}
+
+//returns total memory and total free memory(not necessarily consequtive) in mmu
+cudaError_t SlabMemoryManager::MemGetInfo(int device_id, size_t* total,
+                                           size_t* free) {
+  std::lock_guard<std::mutex> lock(mutex_[device_id]);
+  buddy_[device_id]->MemoryUsage(total, free);
+  return cudaSuccess;
+}
+
+bool SlabMemoryManager::TryAllocate(int device_id, size_t size) {
+  std::lock_guard<std::mutex> lock(mutex_[device_id]);
+  return buddy_[device_id]->TryAllocate(size);
+}
+*/
+// Factory functions.
+std::shared_ptr<MemoryManager> GetMemoryManagerRef() {
+  static std::shared_ptr<MemoryManager> inst;
+  static bool set = false;
+  if (!set) {
+    std::string mem_mgr_type = dmlc::GetEnv("MXNET_MEM_MGR_TYPE",
+                                            std::string("CUDA"));
+    bool infinite_memory = dmlc::GetEnv("MXNET_INFINITE_MEMORY", false);
+    if (infinite_memory) {
+        mem_mgr_type = "Buddy";
+    }
+    std::cout << "MXNET_MEM_MGR_TYPE: " << mem_mgr_type << std::endl;
+    if (mem_mgr_type == "CUDA") {
+      inst.reset(dynamic_cast<MemoryManager*>(new CudaMemoryManager()));
+    } else if (mem_mgr_type == "Buddy") {
+      inst.reset(dynamic_cast<MemoryManager*>(new BuddyMemoryManager()));
+    } else if (mem_mgr_type == "FAKE") {
+      inst.reset(dynamic_cast<MemoryManager*>(new FakeMemoryManager()));
+    } else {
+      CHECK(false);
+    }
+    set = true;
+  }
+  return inst;
+}
+
+MemoryManager* GetMemoryManager() {
+  static MemoryManager* mm = GetMemoryManagerRef().get();
+  return mm;
+}
+
+} // namespace mxnet

--- a/src/storage/gpu_swap_memmgr.h
+++ b/src/storage/gpu_swap_memmgr.h
@@ -1,0 +1,130 @@
+#ifndef MXNET_GPU_SWAP_MEMMGR_H_
+#define MXNET_GPU_SWAP_MEMMGR_H_
+
+#include <atomic>
+#include <cuda_runtime_api.h>
+#include <iostream>
+#include <map>
+#include <math.h>
+#include <memory>
+#include <mutex>
+#include <stdio.h>
+#include <string>
+
+#include "./gpu_swap_buddy.h"
+#include "./gpu_swap_history.h"
+
+namespace mxnet {
+
+// Save some memory for each device(subject to change).
+
+class MemoryManager {
+  public:
+    static constexpr double kGPUUtilRatio = 0.95;
+    static const size_t kMB = 1L << 20;
+    static const size_t kGB = 1L << 30;
+
+    cudaError_t Memcpy(int device_id, void* dst, const void* src, size_t count,
+                       cudaMemcpyKind kind);
+    cudaError_t MemcpyAsync(int device_id, void* dst, const void* src,
+                            size_t count, cudaMemcpyKind kind,
+                            cudaStream_t stream);
+    cudaError_t StreamSynchronize(int device_id, cudaStream_t stream);
+    virtual cudaError_t MemGetInfo(int device_id, size_t* total,
+                                   size_t* free) = 0;
+    virtual bool TryAllocate(int device_id, size_t size) = 0;
+    cudaError_t Malloc(void*& devptr, size_t size, int device_id);
+    cudaError_t Free(void* devptr, int device_id);
+    void Statistics();
+
+  protected:
+    virtual cudaError_t MallocInternal(void*& devptr, size_t size,
+                                       int device_id) = 0;
+    virtual cudaError_t FreeInternal(void* devptr, int device_id) = 0;
+    virtual void StatisticsInternal() = 0;
+    std::array<std::atomic_size_t, 16> malloc_count_;
+    std::array<std::atomic_size_t, 16> malloc_size_;
+    std::array<std::atomic_size_t, 16> free_count_;
+    std::array<std::unordered_map<size_t, int>, 16> malloc_type_;
+}; // Class MemoryManager
+
+class CudaMemoryManager : public MemoryManager {
+  public:
+    cudaError_t MemGetInfo(int device_id, size_t* total, size_t* free);
+    bool TryAllocate(int device_id, size_t size);
+
+    friend std::shared_ptr<MemoryManager> GetMemoryManagerRef();
+
+  protected:
+    cudaError_t MallocInternal(void*& devptr, size_t size, int device_id);
+    cudaError_t FreeInternal(void* devptr, int device_id);
+    void StatisticsInternal();
+
+  private:
+    CudaMemoryManager();
+    ~CudaMemoryManager();
+}; // Class CudaMemoryManager
+
+class BuddyMemoryManager : public MemoryManager {
+  public:
+    cudaError_t MemGetInfo(int device_id, size_t* total, size_t* free);
+    bool TryAllocate(int device_id, size_t size);
+
+    friend std::shared_ptr<MemoryManager> GetMemoryManagerRef();
+
+  protected:
+    cudaError_t MallocInternal(void*& devptr, size_t size, int device_id);
+    cudaError_t FreeInternal(void* devptr, int device_id);
+    void StatisticsInternal();
+
+  private:
+    BuddyMemoryManager();
+    ~BuddyMemoryManager();
+
+    std::vector<BuddySystem*> buddy_;
+    // Note that this line means we assume there will no more than 16 GPUs.
+    std::array<std::mutex, 16> mutex_;
+}; // Class BuddyMemoryManager
+
+class FakeMemoryManager : public MemoryManager {
+  public:
+    cudaError_t MemGetInfo(int device_id, size_t* total, size_t* free);
+    bool TryAllocate(int device_id, size_t size);
+
+    friend std::shared_ptr<MemoryManager> GetMemoryManagerRef();
+
+  protected:
+    cudaError_t MallocInternal(void*& devptr, size_t size, int device_id);
+    cudaError_t FreeInternal(void* devptr, int device_id);
+    void StatisticsInternal();
+
+  private:
+    FakeMemoryManager();
+    ~FakeMemoryManager();
+    
+    std::vector<void*> ptrs_;
+}; // Class BuddyMemoryManager
+
+
+//class SlabMemoryManager : public MemoryManager {
+  //public:
+    //cudaError_t MemGetInfo(int device_id, size_t* total, size_t* free);
+    //bool TryAllocate(int device_id, size_t size);
+
+    //friend std::shared_ptr<MemoryManager> GetMemoryManagerRef();
+    //
+  //protected:
+    //cudaError_t MallocInternal(void*& devptr, size_t size, int device_id);
+    //cudaError_t FreeInternal(void* devptr, int device_id);
+    //void StatisticsInternal();
+
+  //private:
+    //SlabMemoryManager();
+    //~SlabMemoryManager();
+//}; // Class SlabMemoryManager
+std::shared_ptr<MemoryManager> GetMemoryManagerRef();
+MemoryManager* GetMemoryManager();
+
+} // namespace mxnet
+
+#endif // MXNET_MEM_MGR_H_

--- a/src/storage/gpu_swap_prefetch.cc
+++ b/src/storage/gpu_swap_prefetch.cc
@@ -1,0 +1,158 @@
+#include <iostream>
+#include <fstream>
+#include <unistd.h>
+#include <vector>
+#include <map>
+#include <dmlc/parameter.h>
+#include <dmlc/logging.h>
+#include "./gpu_swap.h"
+#include "./gpu_swap_history.h"
+#include "./gpu_swap_prefetch.h"
+
+
+namespace mxnet {
+
+Prefetch::Prefetch() {
+  start_prefetching_ = false;
+  stop_prefetching_ = false;
+  computing_ = false;
+  prefetch_algorithm_ = dmlc::GetEnv("MXNET_PREFETCH_ALGORITHM",
+                                      std::string("NaiveHistory"));
+  steps_ahead_ = dmlc::GetEnv("MXNET_PREFETCH_STEP_AHEAD", 100);
+  bool infinite_memory = dmlc::GetEnv("MXNET_INFINITE_MEMORY", false);
+  if (infinite_memory) {
+      prefetch_algorithm_ = "NoPrefetch";
+  }
+  history_ = MemoryHistory::_GetSharedRef();
+  lookahead_pos_.resize(NUMBER_OF_GPU);
+  prefetcher_.resize(NUMBER_OF_GPU);
+  for (int i = 0; i < NUMBER_OF_GPU; i++) {
+    lookahead_pos_[i] = 0;
+  }
+  std::cout << "Prefetch Algorithm: " << prefetch_algorithm_ << std::endl;
+  std::cout << "Prefetch Steps Ahead: " << steps_ahead_ << std::endl;
+  if (prefetch_algorithm_ == "NaiveHistory") {
+    DoPrefetch = &Prefetch::HistoryBasedPrefetch;
+  } else if (prefetch_algorithm_ == "ComputePrefetch") {
+    DoPrefetch = &Prefetch::PrefetchWhileComputing;
+  } else if (prefetch_algorithm_ == "NoPrefetch") {
+    DoPrefetch = nullptr;
+  } else {
+    std::cout << "Unknown Prefetch Algorithm: " << prefetch_algorithm_
+      << std::endl;
+    CHECK(0);
+  }
+}
+
+Prefetch::~Prefetch() {}
+
+Prefetch* Prefetch::Get() {
+  static Prefetch *s = _GetSharedRef().get();
+  return s;
+}
+
+std::shared_ptr<Prefetch> Prefetch::_GetSharedRef() {
+  static std::shared_ptr<Prefetch> inst(new Prefetch());
+  return inst;
+}
+
+
+void Prefetch::SignalStartComputing() {
+  computing_ = true;
+}
+
+
+void Prefetch::SignalStopComputing() {
+  computing_ = false;
+}
+
+
+void Prefetch::StartPrefetching() {
+  start_prefetching_ = false;
+  stop_prefetching_ = false;
+  if (DoPrefetch == nullptr) {
+    return;
+  }
+  for (int device = 0; device < NUMBER_OF_GPU; device++) {
+    prefetcher_[device] = std::thread(&Prefetch::Prefetching, this, device);
+  }
+  //while (!Prefetch::Get()->IsPrefetching()) {
+    //usleep(1);
+  //}
+}
+
+
+void Prefetch::StopPrefetching() {
+  stop_prefetching_ = true;
+  for (int device = 0; device < NUMBER_OF_GPU; device++) {
+    prefetcher_[device].join();
+    lookahead_pos_[device] = 0;
+  }
+  // Swap::Get()->PrintHandles();
+}
+
+
+void Prefetch::Prefetching(int device) {
+  while (!stop_prefetching_) {
+    (this->*DoPrefetch)(device);
+    start_prefetching_ = true;
+  }
+}
+
+
+void Prefetch::PrefetchWhileComputing(int device) {
+  //TODO(karl): Use condition variable to replace the inefficient busy waiting
+
+  /*
+  std::unique_lock<std::mutex> lk(prefetch_lock_[device]);
+  while (!computing_) {
+    prefetch_cond_[device].wait(lk);
+  }
+  while (!computing_)
+    usleep(1);
+  */
+  auto& history = history_->DevHistory(device);
+  if (lookahead_pos_[device] < history.curr_idx) {
+    lookahead_pos_[device] = history.curr_idx;
+  }
+  while (lookahead_pos_[device] + 1 < history.ordered_history->size() &&
+         lookahead_pos_[device] >= history.curr_idx &&
+         lookahead_pos_[device] - history.curr_idx < steps_ahead_ &&
+         computing_) {
+    MemoryHistory::MemRecord r =
+        (*history.ordered_history)[++lookahead_pos_[device]];
+    if (r.operation_id == MemoryHistory::GET_ADDR) {
+      ++history.prefetch_count;
+      Swap::Get()->GetAddr(r.handle_id, true);
+    } else {
+      std::cout << "non-read operation found" << std::endl;
+    }
+  }
+}
+
+// TODO(sotskin): karll: Add algorithm discription
+void Prefetch::HistoryBasedPrefetch(int device) {
+  //pthread_rwlock_rdlock(&swap_lock_);
+  //bool has_begun = false;
+  auto& history = history_->DevHistory(device);
+  if (lookahead_pos_[device] < history.curr_idx) {
+    lookahead_pos_[device] = history.curr_idx;
+  }
+  while (lookahead_pos_[device] + 1 < history.ordered_history->size() &&
+         lookahead_pos_[device] >= history.curr_idx &&
+         lookahead_pos_[device] - history.curr_idx < steps_ahead_) {
+    MemoryHistory::MemRecord r =
+        (*history.ordered_history)[++lookahead_pos_[device]];
+    if (r.operation_id == MemoryHistory::GET_ADDR) {
+      ++history.prefetch_count;
+      Swap::Get()->GetAddr(r.handle_id, true);
+    } else {
+      std::cout << "non-read operation found" << std::endl;
+    }
+  }
+  usleep(1);
+  //pthread_rwlock_unlock(&swap_lock_);
+}
+
+
+} // namespace mxnet

--- a/src/storage/gpu_swap_prefetch.h
+++ b/src/storage/gpu_swap_prefetch.h
@@ -1,0 +1,45 @@
+#ifndef GPU_SWAP_PREFETCH_H
+#define GPU_SWAP_PREFETCH_H
+
+#include <thread>
+
+#if MXNET_USE_CUDA
+#include <cuda_runtime.h>
+#endif
+#include "./gpu_swap_history.h"
+
+namespace mxnet {
+
+class Prefetch {
+public:
+  ~Prefetch();
+  static Prefetch* Get();
+  static std::shared_ptr<Prefetch> _GetSharedRef();
+  void StartPrefetching();
+  void StopPrefetching();
+  void SignalStartComputing();
+  void SignalStopComputing();
+  bool IsPrefetching() {return start_prefetching_;}
+
+private:
+  Prefetch();
+  void Prefetching(int device);
+  void (Prefetch::*DoPrefetch)(int);
+  // Prefetch algorithm declarations
+  void HistoryBasedPrefetch(int device);
+  void PrefetchWhileComputing(int device);
+
+  bool computing_;
+  std::vector<size_t> lookahead_pos_;
+  std::vector<std::thread> prefetcher_;
+  std::shared_ptr<MemoryHistory> history_;
+  bool start_prefetching_;
+  bool stop_prefetching_;
+  std::string prefetch_algorithm_;
+  size_t steps_ahead_;
+}; // class prefetch
+
+} // namespace mxnet
+
+
+#endif

--- a/src/storage/gpu_swap_util.h
+++ b/src/storage/gpu_swap_util.h
@@ -1,0 +1,16 @@
+#ifndef MXNET_GPU_SWAP_UTIL_H_
+#define MXNET_GPU_SWAP_UTIL_H_
+#include <string>
+
+namespace mxnet {
+static inline std::string MBString(size_t size) {
+  return std::to_string(size / 1e6) + "MB";
+}
+
+static inline std::string GBString(size_t size) {
+  return std::to_string(size / 1e9) + "GB";
+}
+
+} // namespace mxnet
+
+#endif // MXNET_GPU_SWAP_UTIL_H_

--- a/src/storage/on_demand_swap_mm_dptr.h
+++ b/src/storage/on_demand_swap_mm_dptr.h
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <vector>
 #include "./gpu_swap.h"
+#define SWAP_ADVISOR_FLOW_TRACE 1
 
 namespace mxnet {
 namespace storage {

--- a/src/storage/on_demand_swap_storage_manager.h
+++ b/src/storage/on_demand_swap_storage_manager.h
@@ -1,0 +1,164 @@
+/* * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2015 by Contributors
+ * \file pooled_storage_manager.h
+ * \brief Storage manager with a memory pool.
+ */
+#ifndef MXNET_STORAGE_POOLED_STORAGE_MANAGER_H_
+#define MXNET_STORAGE_POOLED_STORAGE_MANAGER_H_
+
+#if MXNET_USE_CUDA
+  #include <cuda_runtime.h>
+#endif  // MXNET_USE_CUDA
+#include <mxnet/base.h>
+#include <mxnet/storage.h>
+#include <unordered_map>
+#include <vector>
+#include <mutex>
+#include <new>
+#include "./gpu_swap.h"
+#include "./storage_manager.h"
+#include "../common/cuda_utils.h"
+
+
+namespace mxnet {
+namespace storage {
+
+#if MXNET_USE_CUDA
+/*!
+ * \brief Storage manager with a memory pool on gpu.
+ */
+class GpuOnDemandSwapStorageManager final : public StorageManager {
+ public:
+  /*!
+   * \brief Default constructor.
+   */
+  GpuOnDemandSwapStorageManager(int device_id) {
+    reserve_ = dmlc::GetEnv("MXNET_GPU_MEM_POOL_RESERVE", 5);
+    //memory_manager_ = MemoryManager::_GetSharedRef();
+    memory_manager_ = GetMemoryManagerRef();
+    swap_ = Swap::_GetSharedRef();
+    do_reuse_ = true;
+    device_id_ = device_id;
+  }
+  /*!
+   * \brief Default destructor.
+   */
+  ~GpuOnDemandSwapStorageManager() {
+    ReleaseAll();
+  }
+
+  void Alloc(Storage::Handle* handle) override;
+  void Free(Storage::Handle handle) override;
+
+  void DirectFree(Storage::Handle handle) override {
+    std::lock_guard<std::mutex> lock(Storage::Get()->GetMutex(Context::kGPU));
+    DirectFreeNoLock(handle);
+  }
+
+ private:
+  void DirectFreeNoLock(Storage::Handle handle) {
+    size_t size = handle.size + NDEV;
+    handle.Free();
+    used_memory_ -= size;
+  }
+ 
+ private:
+  void ReleaseAll();
+  // used memory
+  size_t used_memory_ = 0;
+  // percentage of reserved memory
+  int reserve_;
+  // shared pointer for swap
+  std::shared_ptr<Swap> swap_;
+  // number of devices
+  const int NDEV = 0;
+  //shared pointer for memory manager
+  std::shared_ptr<MemoryManager> memory_manager_;
+  // memory pool
+  std::unordered_map<size_t, std::vector<void*>> memory_pool_;
+  // whether to reuse freed memory
+  bool do_reuse_;
+  int device_id_;
+  DISALLOW_COPY_AND_ASSIGN(GpuOnDemandSwapStorageManager);
+};  // class GpuOnDemandSwapStorageManager
+
+void GpuOnDemandSwapStorageManager::Alloc(Storage::Handle* handle) {
+  std::lock_guard<std::mutex> lock(Storage::Get()->GetMutex(Context::kGPU));
+  size_t size = handle->size + NDEV;
+  auto&& reuse_it = memory_pool_.find(size);
+  if (reuse_it == memory_pool_.end() || reuse_it->second.size() == 0) {
+    size_t free, total;
+    memory_manager_->MemGetInfo(device_id_, &total, &free);
+    if (do_reuse_ && 
+        (free <= total*reserve_/100 || size > free - total*reserve_/100)) {
+      do_reuse_ = false;
+      ReleaseAll();
+    }
+    swap_->SwapOutLocked(size, device_id_, false);
+    void* ret = nullptr;
+    cudaError_t e = memory_manager_->Malloc(ret, size, device_id_);
+    if (e != cudaSuccess && e != cudaErrorCudartUnloading) {
+      LOG(FATAL) << "cudaMalloc failed: " << cudaGetErrorString(e);
+    }
+    used_memory_ += size;
+    handle->SetDptr(ret, device_id_);
+  } else {
+    auto&& reuse_pool = reuse_it->second;
+    auto ret = reuse_pool.back();
+    reuse_pool.pop_back();
+    handle->SetDptr(ret, device_id_);
+  }
+}
+
+void GpuOnDemandSwapStorageManager::Free(Storage::Handle handle) {
+  std::lock_guard<std::mutex> lock(Storage::Get()->GetMutex(Context::kGPU));
+  // If do reuse, no swapping has happened yet.
+  if (do_reuse_) {
+    size_t size = handle.size + NDEV;
+    auto&& reuse_pool = memory_pool_[size];
+    reuse_pool.push_back(handle.GetDptr());
+    // The address will be set to a different handle later
+    handle.FreeDptr();
+  } else {
+    DirectFreeNoLock(handle);
+  }
+}
+
+void GpuOnDemandSwapStorageManager::ReleaseAll() {
+  for (auto&& i : memory_pool_) {
+    for (auto&& j : i.second) {
+      cudaError_t e = memory_manager_->Free(j, device_id_);
+      if (e != cudaSuccess && e != cudaErrorCudartUnloading) {
+        LOG(FATAL) << "cudaFree failed: " << cudaGetErrorString(e);
+      }
+      size_t size = i.first - NDEV;
+      used_memory_ -= size;
+    }
+  }
+  memory_pool_.clear();
+}
+
+#endif  // MXNET_USE_CUDA
+
+}  // namespace storage
+}  // namespace mxnet
+
+#endif  // MXNET_STORAGE_POOLED_STORAGE_MANAGER_H_

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -126,18 +126,18 @@ void StorageImpl::Alloc(Storage::Handle* handle) {
             std::string strategy = type;
 
             if (strategy == "Round") {
-                ptr = new storage::GPUPooledRoundedStorageManager();
-                LOG(INFO) << "Using GPUPooledRoundedStorageManager.";
+              ptr = new storage::GPUPooledRoundedStorageManager();
+              LOG(INFO) << "Using GPUPooledRoundedStorageManager.";
             } else if (strategy == "OnDemandSwap") {
-                ptr = new storage::GPUOnDemandSwapStorageManager(
-                      handle->ctx.real_dev_id());
-                //ptr = new storage::GPUPooledStorageManager();
-                LOG(INFO) << "Using GPUOnDemandSwapStorageManager.";
+              ptr = new storage::GPUOnDemandSwapStorageManager(
+                    handle->ctx.real_dev_id());
+              //ptr = new storage::GPUPooledStorageManager();
+              LOG(INFO) << "Using GPUOnDemandSwapStorageManager.";
             } else {
-                if (strategy != "Naive") {
-                    LOG(FATAL) << "Unknown memory pool strategy specified: " << strategy << ".";
-                }
-                ptr = new storage::GPUPooledStorageManager();
+              if (strategy != "Naive") {
+                  LOG(FATAL) << "Unknown memory pool strategy specified: " << strategy << ".";
+              }
+              ptr = new storage::GPUPooledStorageManager();
             }
 #else
             LOG(FATAL) << "Compile with USE_CUDA=1 to enable GPU usage";

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -129,7 +129,7 @@ void StorageImpl::Alloc(Storage::Handle* handle) {
             if (strategy == "Round") {
               ptr = new storage::GPUPooledRoundedStorageManager();
               LOG(INFO) << "Using GPUPooledRoundedStorageManager.";
-            } else if (strategy == "OnDemandSwap") {
+            } else if (strategy == "SwapOnDemand") {
               ptr = new storage::GPUOnDemandSwapStorageManager(
                     handle->ctx.real_dev_id());
               //ptr = new storage::GPUPooledStorageManager();

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -125,13 +125,16 @@ void StorageImpl::Alloc(Storage::Handle* handle) {
             std::string strategy = type;
 
             if (strategy == "Round") {
-              ptr = new storage::GPUPooledRoundedStorageManager();
-              LOG(INFO) << "Using GPUPooledRoundedStorageManager.";
+                ptr = new storage::GPUPooledRoundedStorageManager();
+                LOG(INFO) << "Using GPUPooledRoundedStorageManager.";
+            } else if (strategy == "OnDemandSwap") {
+                ptr = new storage::GpuOnDemandSwapStorageManager();
+                LOG(INFO) << "Using GpuOnDemandSwapStorageManager.";
             } else {
-              if (strategy != "Naive") {
-                LOG(FATAL) << "Unknown memory pool strategy specified: " << strategy << ".";
-              }
-              ptr = new storage::GPUPooledStorageManager();
+                if (strategy != "Naive") {
+                    LOG(FATAL) << "Unknown memory pool strategy specified: " << strategy << ".";
+                }
+                ptr = new storage::GPUPooledStorageManager();
             }
 #else
             LOG(FATAL) << "Compile with USE_CUDA=1 to enable GPU usage";

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -24,6 +24,7 @@
 #include "./storage_manager.h"
 #include "./naive_storage_manager.h"
 #include "./pooled_storage_manager.h"
+#include "./on_demand_swap_storage_manager.h"
 #include "./cpu_shared_storage_manager.h"
 #include "./cpu_device_storage.h"
 #include "./pinned_memory_storage.h"
@@ -128,8 +129,10 @@ void StorageImpl::Alloc(Storage::Handle* handle) {
                 ptr = new storage::GPUPooledRoundedStorageManager();
                 LOG(INFO) << "Using GPUPooledRoundedStorageManager.";
             } else if (strategy == "OnDemandSwap") {
-                ptr = new storage::GpuOnDemandSwapStorageManager();
-                LOG(INFO) << "Using GpuOnDemandSwapStorageManager.";
+                ptr = new storage::GPUOnDemandSwapStorageManager(
+                      handle->ctx.real_dev_id());
+                //ptr = new storage::GPUPooledStorageManager();
+                LOG(INFO) << "Using GPUOnDemandSwapStorageManager.";
             } else {
                 if (strategy != "Naive") {
                     LOG(FATAL) << "Unknown memory pool strategy specified: " << strategy << ".";


### PR DESCRIPTION
Move the implementation of  on-demand swapping from gpu_swap to current branch.
1. It now uses OnDemandSwapStorageManager instead of PooledStorageManager.
2. Since address interception is on-going, all lines related to handle->dptr is commented out.